### PR TITLE
Add nested policy comparison utilities and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: .
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest numpy stim
+      - name: Run pytest
+        run: pytest

--- a/surface_code_in_stem/__init__.py
+++ b/surface_code_in_stem/__init__.py
@@ -1,0 +1,23 @@
+"""Surface code builders and helpers."""
+
+from .surface_code import surface_code_circuit_string
+from .dynamic_surface_codes import (
+    DynamicLayout,
+    StimStringBuilder,
+    hexagonal_surface_code,
+    iswap_surface_code,
+    walking_surface_code,
+)
+from .rl_nested_learning import compare_nested_policies, tabulate_comparison
+
+__all__ = [
+    "surface_code_circuit_string",
+    "DynamicLayout",
+    "StimStringBuilder",
+    "hexagonal_surface_code",
+    "iswap_surface_code",
+    "walking_surface_code",
+    "compare_nested_policies",
+    "tabulate_comparison",
+]
+

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -1,0 +1,76 @@
+"""Helpers for quickly comparing nested surface-code policies.
+
+The helpers in this module run tiny Stim simulations for both the original
+static surface code builder and one of the dynamic builders. They return simple
+tables of logical error rates that can be consumed by notebooks or tests
+without requiring long simulation times.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable
+
+import numpy as np
+
+from surface_code_in_stem.dynamic import hexagonal_surface_code
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+
+StimBuilder = Callable[[int, int, float], str]
+
+
+def _logical_error_rate(circuit_string: str, shots: int, seed: int | None) -> float:
+    try:
+        import stim
+    except ModuleNotFoundError as exc:  # pragma: no cover - handled by tests
+        raise ImportError("Stim is required to sample logical error rates.") from exc
+
+    circuit = stim.Circuit(circuit_string)
+    detector_sampler = circuit.compile_detector_sampler(seed=seed)
+    detector_samples = detector_sampler.sample(shots)
+    return float(np.mean(np.any(detector_samples, axis=1)))
+
+
+def compare_nested_policies(
+    *,
+    distance: int,
+    rounds: int,
+    p: float,
+    shots: int,
+    seed: int | None = None,
+    static_builder: StimBuilder = surface_code_circuit_string,
+    dynamic_builder: StimBuilder = hexagonal_surface_code,
+) -> Dict[str, Dict[str, float | int | str | None]]:
+    """Run small simulations for static and dynamic builders.
+
+    Returns a dictionary keyed by policy name containing the logical error rate
+    and the simulation metadata used to generate it.
+    """
+
+    policies: Dict[str, StimBuilder] = {
+        "static": static_builder,
+        "dynamic": dynamic_builder,
+    }
+    results: Dict[str, Dict[str, float | int | str | None]] = {}
+
+    for name, builder in policies.items():
+        circuit_str = builder(distance, rounds, p)
+        results[name] = {
+            "builder": builder.__name__,
+            "distance": distance,
+            "rounds": rounds,
+            "p": p,
+            "shots": shots,
+            "seed": seed,
+            "logical_error_rate": _logical_error_rate(circuit_str, shots, seed),
+        }
+
+    return results
+
+
+def tabulate_comparison(comparison: Dict[str, Dict[str, float | int | str | None]]) -> Iterable[Dict[str, float | int | str | None]]:
+    """Flatten a comparison dictionary into a list of rows."""
+
+    for policy, metrics in comparison.items():
+        yield {"policy": policy, **metrics}
+

--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+stim = pytest.importorskip("stim")
+
+from surface_code_in_stem.rl_nested_learning import compare_nested_policies, tabulate_comparison
+
+
+def test_compare_nested_policies_and_tabulation():
+    comparison = compare_nested_policies(
+        distance=3,
+        rounds=3,
+        p=0.001,
+        shots=8,
+        seed=7,
+    )
+
+    assert set(comparison.keys()) == {"static", "dynamic"}
+    for metrics in comparison.values():
+        assert metrics["distance"] == 3
+        assert metrics["rounds"] == 3
+        assert metrics["shots"] == 8
+        assert 0 <= metrics["logical_error_rate"] <= 1
+        assert np.isfinite(metrics["logical_error_rate"])
+
+    rows = list(tabulate_comparison(comparison))
+    assert {row["policy"] for row in rows} == {"static", "dynamic"}
+    for row in rows:
+        assert {"policy", "builder", "logical_error_rate"}.issubset(row.keys())
+        assert np.isfinite(row["logical_error_rate"])
+


### PR DESCRIPTION
## Summary
- add rl_nested_learning helpers that compare static and dynamic surface-code builders
- cover compare_nested_policies and tabulate_comparison with a deterministic pytest
- run pytest in CI with stim and numpy installed

## Testing
- PYTHONPATH=. pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9eb236788328ac65040e8942912b)

## Summary by Sourcery

Add utilities for comparing static and dynamic nested surface-code policies and integrate them into the public package API.

New Features:
- Introduce helpers to run small Stim-based simulations comparing static and dynamic surface-code builders and report logical error rates.
- Provide a tabulation utility that flattens comparison results into row-like dictionaries for downstream consumption.

Enhancements:
- Expose surface-code builders and the new comparison utilities via the package’s public __init__ module.

CI:
- Add a GitHub Actions workflow to run pytest with Stim and NumPy installed on pushes and pull requests.

Tests:
- Add a deterministic pytest covering nested policy comparison and tabulation using Stim and NumPy.