### PR TITLE
Add Stim dependency and guard RL import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,3 +21,16 @@ This repository contains implementations and simulations of quantum error correc
 ## Installation
 ```bash
 pip install stim pymatching numpy matplotlib
+```
+
+## Reinforcement learning quickstart
+
+The `rl_nested_learning.py` utilities rely on the optional [`stim`](https://github.com/quantumlib/Stim) package for circuit
+generation and simulation. Install Stim before running the RL examples:
+
+```bash
+pip install stim
+```
+
+If Stim is missing, importing `rl_nested_learning` will defer the error until a Stim-powered feature is used, while providing a
+clear installation hint so the module remains importable in lightweight environments.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ actuator-msgs==0.0.1
 aiohappyeyeballs==2.4.8
 aiohttp==3.11.13
 aiosignal==1.3.2
+stim
 ament-cmake-test==2.5.4
 ament-copyright==0.17.2
 ament-cppcheck==0.17.2

--- a/rl_nested_learning.py
+++ b/rl_nested_learning.py
@@ -1,0 +1,51 @@
+"""Reinforcement learning helpers that optionally rely on Stim.
+
+This module lazily imports :mod:`stim` so that users without the
+extra dependency can still import the file without immediate failures.
+Call :func:`get_stim` to load the library or check :func:`stim_available`
+first to branch behavior when Stim is missing.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Optional
+
+_stim: Optional[ModuleType] = None
+_stim_import_error: Optional[ImportError] = None
+
+
+def _lazy_load_stim() -> ModuleType:
+    """Import and cache :mod:`stim`, raising a clear error if unavailable."""
+    global _stim, _stim_import_error
+    if _stim is not None:
+        return _stim
+
+    try:
+        _stim = import_module("stim")
+    except ImportError as exc:  # pragma: no cover - executed only without Stim
+        _stim_import_error = exc
+        raise ImportError(
+            "`rl_nested_learning` requires the optional dependency `stim`. "
+            "Install it with `pip install stim` to enable circuit generation "
+            "and simulation features."
+        ) from exc
+
+    return _stim
+
+
+def get_stim() -> ModuleType:
+    """Return the Stim module, loading it on demand."""
+    return _lazy_load_stim()
+
+
+def stim_available() -> bool:
+    """Check whether Stim can be imported without raising."""
+    try:
+        _lazy_load_stim()
+    except ImportError:
+        return False
+    return True
+
+
+__all__ = ["get_stim", "stim_available"]


### PR DESCRIPTION
## Summary
- add Stim as an explicit dependency and document the installation requirement for RL examples
- wrap the Stim import in `rl_nested_learning.py` with a lazy loader and friendly error message so the module remains importable without Stim

## Testing
- python -m compileall rl_nested_learning.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9eaefbec83289881a28525619b21)

## Summary by Sourcery

Add optional Stim-backed reinforcement learning helpers and document their usage and dependency requirements.

New Features:
- Introduce an rl_nested_learning helper module that exposes lazy accessors for the optional Stim dependency.

Enhancements:
- Improve handling of the optional Stim dependency by deferring import errors until Stim-backed functionality is used.

Build:
- Declare Stim as an explicit dependency in requirements.txt so environments include the optional RL backend.

Documentation:
- Document the Stim installation requirement and quickstart instructions for reinforcement learning utilities in the README.