### PR TITLE
Parametrize nested learning test for all dynamic surface-code builders

### DIFF
--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -3,23 +3,34 @@ import pytest
 
 stim = pytest.importorskip("stim")
 
+from surface_code_in_stem.dynamic import (
+    hexagonal_surface_code,
+    iswap_surface_code,
+    walking_surface_code,
+)
 from surface_code_in_stem.rl_nested_learning import compare_nested_policies, tabulate_comparison
 
 
-def test_compare_nested_policies_and_tabulation():
+@pytest.mark.parametrize(
+    "dynamic_builder",
+    [hexagonal_surface_code, iswap_surface_code, walking_surface_code],
+    ids=["hexagonal", "iswap", "walking"],
+)
+def test_compare_nested_policies_and_tabulation(dynamic_builder):
     comparison = compare_nested_policies(
         distance=3,
-        rounds=3,
+        rounds=1,
         p=0.001,
-        shots=8,
+        shots=4,
         seed=7,
+        dynamic_builder=dynamic_builder,
     )
 
     assert set(comparison.keys()) == {"static", "dynamic"}
     for metrics in comparison.values():
         assert metrics["distance"] == 3
-        assert metrics["rounds"] == 3
-        assert metrics["shots"] == 8
+        assert metrics["rounds"] == 1
+        assert metrics["shots"] == 4
         assert 0 <= metrics["logical_error_rate"] <= 1
         assert np.isfinite(metrics["logical_error_rate"])
 
@@ -28,4 +39,3 @@ def test_compare_nested_policies_and_tabulation():
     for row in rows:
         assert {"policy", "builder", "logical_error_rate"}.issubset(row.keys())
         assert np.isfinite(row["logical_error_rate"])
-

--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 stim = pytest.importorskip("stim")
 
@@ -28,7 +29,7 @@ def test_compare_nested_policies_and_tabulation(dynamic_builder):
 
     comparison = compare_nested_policies(
         distance=3,
-        rounds=1,
+        rounds=2,
         p=0.001,
         shots=4,
         seed=7,
@@ -40,14 +41,19 @@ def test_compare_nested_policies_and_tabulation(dynamic_builder):
         metrics = comparison[policy]
         assert set(metrics.keys()) == expected_keys
         assert metrics["distance"] == 3
-        assert metrics["rounds"] == 3
-        assert metrics["shots"] == 8
+        assert metrics["rounds"] == 2
+        assert metrics["shots"] == 4
         # Logical error rate is the fraction of shots where logical observable 0 flipped.
         assert 0 <= metrics["logical_error_rate"] <= 1
         assert np.isfinite(metrics["logical_error_rate"])
 
     rows = list(tabulate_comparison(comparison))
     assert {row["policy"] for row in rows} == {"static", "dynamic"}
+    assert {
+        row["builder"]
+        for row in rows
+        if row["policy"] == "dynamic"
+    } == {dynamic_builder.__name__}
     for row in rows:
         assert set(row.keys()) == {"policy", *expected_keys}
         assert np.isfinite(row["logical_error_rate"])

--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -11,7 +11,11 @@ from surface_code_in_stem.dynamic import (
 from surface_code_in_stem.rl_nested_learning import compare_nested_policies, tabulate_comparison
 
 
-def test_compare_nested_policies_and_tabulation():
+@pytest.mark.parametrize(
+    "dynamic_builder",
+    [hexagonal_surface_code, iswap_surface_code, walking_surface_code],
+)
+def test_compare_nested_policies_and_tabulation(dynamic_builder):
     expected_keys = {
         "builder",
         "distance",


### PR DESCRIPTION
### Motivation
- Ensure the nested policy comparison test exercises all dynamic surface-code builders (`hexagonal`, `iswap`, `walking`) so regressions in any variant are caught.
- Keep CI runtime low by using very small simulation parameters while preserving deterministic behavior to reduce flakiness.

### Description
- Import `hexagonal_surface_code`, `iswap_surface_code`, and `walking_surface_code` from `surface_code_in_stem.dynamic` and add them to the test imports.
- Parametrize `test_compare_nested_policies_and_tabulation` over the three builder functions and pass each via `dynamic_builder=...` into `compare_nested_policies`.
- Reduce simulation workload to `rounds=1` and `shots=4` while keeping `distance=3` and a fixed `seed=7` for determinism.
- Maintain assertions that the returned metrics contain the expected schema and that `logical_error_rate` is finite and within `[0, 1]` for both `static` and `dynamic` policies.

### Testing
- Ran `pytest -q tests/test_rl_nested_learning.py` to validate the new parametrized test; test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).
- No other automated tests were executed in this environment because the missing `numpy` prevented test collection and run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb993efd48328af44d41556a6d5b2)

## Summary by Sourcery

Tests:
- Parametrize `test_compare_nested_policies_and_tabulation` over the hexagonal, iswap, and walking dynamic surface-code builders to validate each variant with shared assertions.