### PR TITLE
Tighten key-shape assertions for nested RL policy comparison tests

### DIFF
--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -7,6 +7,16 @@ from surface_code_in_stem.rl_nested_learning import compare_nested_policies, tab
 
 
 def test_compare_nested_policies_and_tabulation():
+    expected_keys = {
+        "builder",
+        "distance",
+        "rounds",
+        "p",
+        "shots",
+        "seed",
+        "logical_error_rate",
+    }
+
     comparison = compare_nested_policies(
         distance=3,
         rounds=3,
@@ -16,7 +26,9 @@ def test_compare_nested_policies_and_tabulation():
     )
 
     assert set(comparison.keys()) == {"static", "dynamic"}
-    for metrics in comparison.values():
+    for policy in ("static", "dynamic"):
+        metrics = comparison[policy]
+        assert set(metrics.keys()) == expected_keys
         assert metrics["distance"] == 3
         assert metrics["rounds"] == 3
         assert metrics["shots"] == 8
@@ -26,6 +38,5 @@ def test_compare_nested_policies_and_tabulation():
     rows = list(tabulate_comparison(comparison))
     assert {row["policy"] for row in rows} == {"static", "dynamic"}
     for row in rows:
-        assert {"policy", "builder", "logical_error_rate"}.issubset(row.keys())
+        assert set(row.keys()) == {"policy", *expected_keys}
         assert np.isfinite(row["logical_error_rate"])
-


### PR DESCRIPTION
### Motivation
- Make the unit test assert the exact metric payload shape returned by `compare_nested_policies` to detect API or serialization regressions.
- Strengthen `tabulate_comparison` validation so each output row is required to contain `policy` plus the same metric keys, improving robustness of downstream consumers.

### Description
- Introduced an `expected_keys` set containing `builder`, `distance`, `rounds`, `p`, `shots`, `seed`, and `logical_error_rate` and assert `set(metrics.keys()) == expected_keys` for both `static` and `dynamic` results from `compare_nested_policies`.
- Tightened tabulation checks to assert `set(row.keys()) == {"policy", *expected_keys}` for every row produced by `tabulate_comparison`, and left the existing `stim = pytest.importorskip("stim")` gate unchanged.

### Testing
- Ran `pytest -q tests/test_rl_nested_learning.py`, which failed during collection in this environment due to a missing dependency: `ModuleNotFoundError: No module named 'numpy'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb992c7f0832888e5e7bd7175104c)

## Summary by Sourcery

Tests:
- Strengthen the nested RL policy comparison test to assert the exact set of metric keys returned for both static and dynamic policies, and to require each tabulated row to contain the policy field plus the same metric keys.