### PR TITLE
Validate inputs in compare_nested_policies and add negative tests

### DIFF
--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -47,6 +47,25 @@ def compare_nested_policies(
     and the simulation metadata used to generate it.
     """
 
+    if not isinstance(distance, int):
+        raise ValueError("distance must be an integer.")
+    if distance < 3 or distance % 2 == 0:
+        raise ValueError("distance must be an odd integer >= 3.")
+
+    if not isinstance(rounds, int) or rounds <= 0:
+        raise ValueError("rounds must be a positive integer.")
+
+    if not isinstance(shots, int) or shots <= 0:
+        raise ValueError("shots must be a positive integer.")
+
+    if not isinstance(p, float) or not 0.0 <= p <= 1.0:
+        raise ValueError("p must be a float between 0 and 1 (inclusive).")
+
+    if not callable(static_builder):
+        raise ValueError("static_builder must be callable.")
+    if not callable(dynamic_builder):
+        raise ValueError("dynamic_builder must be callable.")
+
     policies: Dict[str, StimBuilder] = {
         "static": static_builder,
         "dynamic": dynamic_builder,
@@ -73,4 +92,3 @@ def tabulate_comparison(comparison: Dict[str, Dict[str, float | int | str | None
 
     for policy, metrics in comparison.items():
         yield {"policy": policy, **metrics}
-

--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -29,3 +29,34 @@ def test_compare_nested_policies_and_tabulation():
         assert {"policy", "builder", "logical_error_rate"}.issubset(row.keys())
         assert np.isfinite(row["logical_error_rate"])
 
+
+@pytest.mark.parametrize("bad_distance", [2, 4, 1.5])
+def test_compare_nested_policies_rejects_invalid_distance(bad_distance):
+    with pytest.raises(ValueError, match="distance"):
+        compare_nested_policies(distance=bad_distance, rounds=3, p=0.001, shots=8)
+
+
+@pytest.mark.parametrize("bad_rounds", [0, -1, 1.2])
+def test_compare_nested_policies_rejects_invalid_rounds(bad_rounds):
+    with pytest.raises(ValueError, match="rounds"):
+        compare_nested_policies(distance=3, rounds=bad_rounds, p=0.001, shots=8)
+
+
+@pytest.mark.parametrize("bad_shots", [0, -5, 2.5])
+def test_compare_nested_policies_rejects_invalid_shots(bad_shots):
+    with pytest.raises(ValueError, match="shots"):
+        compare_nested_policies(distance=3, rounds=3, p=0.001, shots=bad_shots)
+
+
+@pytest.mark.parametrize("bad_p", [-0.1, 1.1, 1])
+def test_compare_nested_policies_rejects_invalid_p(bad_p):
+    with pytest.raises(ValueError, match="p"):
+        compare_nested_policies(distance=3, rounds=3, p=bad_p, shots=8)
+
+
+def test_compare_nested_policies_rejects_non_callable_builders():
+    with pytest.raises(ValueError, match="static_builder"):
+        compare_nested_policies(distance=3, rounds=3, p=0.001, shots=8, static_builder="not callable")
+
+    with pytest.raises(ValueError, match="dynamic_builder"):
+        compare_nested_policies(distance=3, rounds=3, p=0.001, shots=8, dynamic_builder=123)


### PR DESCRIPTION
### Motivation
- Make `compare_nested_policies` fail early on invalid inputs so callers get clear, user-facing errors instead of obscure downstream failures. 
- Catch common misuses (wrong types, out-of-range values, non-callable builders) that would produce invalid Stim circuits or confusing crashes.

### Description
- Added upfront validation in `surface_code_in_stem.rl_nested_learning.compare_nested_policies` to enforce `distance` is an `int` that is odd and `>= 3`.
- Added checks that `rounds` and `shots` are positive `int`s and that `p` is a `float` in the closed interval `[0.0, 1.0]`.
- Added optional builder validation to require `static_builder` and `dynamic_builder` are callable, and raise concise `ValueError` messages for each invalid parameter.
- Added focused negative tests to `tests/test_rl_nested_learning.py` that use `pytest.raises(ValueError)` to exercise invalid `distance`, `rounds`, `shots`, `p`, and non-callable builder cases.

### Testing
- Ran the test module with `PYTHONPATH=. pytest -q tests/test_rl_nested_learning.py` and observed all tests pass (`14 passed`).
- The updated test suite includes the new negative tests which validate the new `ValueError` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb991e9188328bc415d7c2b745e9b)

## Summary by Sourcery

Add upfront input validation to compare_nested_policies and extend tests to cover invalid parameter scenarios.

Bug Fixes:
- Prevent compare_nested_policies from running with invalid distance, rounds, shots, probability, or non-callable builders by raising clear ValueError exceptions.

Tests:
- Add negative tests verifying compare_nested_policies rejects invalid distance, rounds, shots, probability values, and non-callable builder arguments with ValueError.