### PR TITLE
Refactor policy comparison utilities and add Stim dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: .
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest numpy stim
+      - name: Run pytest
+        run: pytest

--- a/RL_EXPERIMENTS.md
+++ b/RL_EXPERIMENTS.md
@@ -1,0 +1,10 @@
+# Reinforcement Learning Experiments
+
+## Reproducibility
+
+The `compare_nested_policies` helper now derives seeds from stable md5 hashes of
+builder and policy names instead of Python's salted `hash` output. This keeps the
+seed assigned to each `(builder, policy)` pair identical across interpreter
+restarts and operating systems. Providing a `base_seed` still allows grouping
+related runs while maintaining deterministic offsets for every individual
+policy.

--- a/Readme.md
+++ b/Readme.md
@@ -21,3 +21,16 @@ This repository contains implementations and simulations of quantum error correc
 ## Installation
 ```bash
 pip install stim pymatching numpy matplotlib
+```
+
+## Reinforcement learning quickstart
+
+The `rl_nested_learning.py` utilities rely on the optional [`stim`](https://github.com/quantumlib/Stim) package for circuit
+generation and simulation. Install Stim before running the RL examples:
+
+```bash
+pip install stim
+```
+
+If Stim is missing, importing `rl_nested_learning` will defer the error until a Stim-powered feature is used, while providing a
+clear installation hint so the module remains importable in lightweight environments.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ actuator-msgs==0.0.1
 aiohappyeyeballs==2.4.8
 aiohttp==3.11.13
 aiosignal==1.3.2
+stim
 ament-cmake-test==2.5.4
 ament-copyright==0.17.2
 ament-cppcheck==0.17.2

--- a/rl_experiments.py
+++ b/rl_experiments.py
@@ -1,0 +1,54 @@
+"""Helpers for comparing RL policy configurations.
+
+This module focuses on deterministic seed generation so that repeated
+experiments remain reproducible regardless of Python's salted hash
+randomization.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, Iterable, Mapping, Tuple
+
+
+def _deterministic_seed(component: str, *, base_seed: int = 0) -> int:
+    """Return a stable integer seed derived from a component name.
+
+    Python's built-in ``hash`` is intentionally salted per interpreter
+    start, which makes seeds derived from it non-reproducible across
+    processes. Instead, this helper uses ``hashlib.md5`` to derive a
+    deterministic 64-bit value and offsets it by ``base_seed`` so that
+    repeated runs always assign the same seed to a given name.
+    """
+
+    digest = hashlib.md5(component.encode("utf-8")).hexdigest()
+    return base_seed + int(digest[:16], 16)
+
+
+def compare_nested_policies(
+    policies: Mapping[str, Iterable[str]], *, base_seed: int = 0
+) -> Dict[Tuple[str, str], int]:
+    """Return deterministic seeds for nested builder/policy pairs.
+
+    Args:
+        policies: Mapping of builder names to the iterable of policy names
+            defined for that builder.
+        base_seed: Optional integer offset that is applied to every seed so
+            that experiments can be grouped under a shared top-level seed
+            while remaining deterministic within each run.
+
+    Returns:
+        A dictionary keyed by ``(builder_name, policy_name)`` tuples with
+        integer seeds that are stable across interpreter invocations.
+
+    Notes:
+        This function previously relied on Python's salted ``hash`` output,
+        which changes between runs. The md5-based strategy here guarantees
+        reproducibility as long as builder and policy names remain constant.
+    """
+
+    seeds: Dict[Tuple[str, str], int] = {}
+    for builder_name, policy_names in policies.items():
+        for policy_name in policy_names:
+            component = f"{builder_name}:{policy_name}"
+            seeds[(builder_name, policy_name)] = _deterministic_seed(component, base_seed=base_seed)
+    return seeds

--- a/rl_nested_learning.py
+++ b/rl_nested_learning.py
@@ -1,0 +1,51 @@
+"""Reinforcement learning helpers that optionally rely on Stim.
+
+This module lazily imports :mod:`stim` so that users without the
+extra dependency can still import the file without immediate failures.
+Call :func:`get_stim` to load the library or check :func:`stim_available`
+first to branch behavior when Stim is missing.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Optional
+
+_stim: Optional[ModuleType] = None
+_stim_import_error: Optional[ImportError] = None
+
+
+def _lazy_load_stim() -> ModuleType:
+    """Import and cache :mod:`stim`, raising a clear error if unavailable."""
+    global _stim, _stim_import_error
+    if _stim is not None:
+        return _stim
+
+    try:
+        _stim = import_module("stim")
+    except ImportError as exc:  # pragma: no cover - executed only without Stim
+        _stim_import_error = exc
+        raise ImportError(
+            "`rl_nested_learning` requires the optional dependency `stim`. "
+            "Install it with `pip install stim` to enable circuit generation "
+            "and simulation features."
+        ) from exc
+
+    return _stim
+
+
+def get_stim() -> ModuleType:
+    """Return the Stim module, loading it on demand."""
+    return _lazy_load_stim()
+
+
+def stim_available() -> bool:
+    """Check whether Stim can be imported without raising."""
+    try:
+        _lazy_load_stim()
+    except ImportError:
+        return False
+    return True
+
+
+__all__ = ["get_stim", "stim_available"]

--- a/surface_code_in_stem/__init__.py
+++ b/surface_code_in_stem/__init__.py
@@ -1,0 +1,23 @@
+"""Surface code builders and helpers."""
+
+from .surface_code import surface_code_circuit_string
+from .dynamic_surface_codes import (
+    DynamicLayout,
+    StimStringBuilder,
+    hexagonal_surface_code,
+    iswap_surface_code,
+    walking_surface_code,
+)
+from .rl_nested_learning import compare_nested_policies, tabulate_comparison
+
+__all__ = [
+    "surface_code_circuit_string",
+    "DynamicLayout",
+    "StimStringBuilder",
+    "hexagonal_surface_code",
+    "iswap_surface_code",
+    "walking_surface_code",
+    "compare_nested_policies",
+    "tabulate_comparison",
+]
+

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -1,0 +1,76 @@
+"""Helpers for quickly comparing nested surface-code policies.
+
+The helpers in this module run tiny Stim simulations for both the original
+static surface code builder and one of the dynamic builders. They return simple
+tables of logical error rates that can be consumed by notebooks or tests
+without requiring long simulation times.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable
+
+import numpy as np
+
+from surface_code_in_stem.dynamic import hexagonal_surface_code
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+
+StimBuilder = Callable[[int, int, float], str]
+
+
+def _logical_error_rate(circuit_string: str, shots: int, seed: int | None) -> float:
+    try:
+        import stim
+    except ModuleNotFoundError as exc:  # pragma: no cover - handled by tests
+        raise ImportError("Stim is required to sample logical error rates.") from exc
+
+    circuit = stim.Circuit(circuit_string)
+    detector_sampler = circuit.compile_detector_sampler(seed=seed)
+    detector_samples = detector_sampler.sample(shots)
+    return float(np.mean(np.any(detector_samples, axis=1)))
+
+
+def compare_nested_policies(
+    *,
+    distance: int,
+    rounds: int,
+    p: float,
+    shots: int,
+    seed: int | None = None,
+    static_builder: StimBuilder = surface_code_circuit_string,
+    dynamic_builder: StimBuilder = hexagonal_surface_code,
+) -> Dict[str, Dict[str, float | int | str | None]]:
+    """Run small simulations for static and dynamic builders.
+
+    Returns a dictionary keyed by policy name containing the logical error rate
+    and the simulation metadata used to generate it.
+    """
+
+    policies: Dict[str, StimBuilder] = {
+        "static": static_builder,
+        "dynamic": dynamic_builder,
+    }
+    results: Dict[str, Dict[str, float | int | str | None]] = {}
+
+    for name, builder in policies.items():
+        circuit_str = builder(distance, rounds, p)
+        results[name] = {
+            "builder": builder.__name__,
+            "distance": distance,
+            "rounds": rounds,
+            "p": p,
+            "shots": shots,
+            "seed": seed,
+            "logical_error_rate": _logical_error_rate(circuit_str, shots, seed),
+        }
+
+    return results
+
+
+def tabulate_comparison(comparison: Dict[str, Dict[str, float | int | str | None]]) -> Iterable[Dict[str, float | int | str | None]]:
+    """Flatten a comparison dictionary into a list of rows."""
+
+    for policy, metrics in comparison.items():
+        yield {"policy": policy, **metrics}
+

--- a/tests/test_rl_nested_learning.py
+++ b/tests/test_rl_nested_learning.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+stim = pytest.importorskip("stim")
+
+from surface_code_in_stem.rl_nested_learning import compare_nested_policies, tabulate_comparison
+
+
+def test_compare_nested_policies_and_tabulation():
+    comparison = compare_nested_policies(
+        distance=3,
+        rounds=3,
+        p=0.001,
+        shots=8,
+        seed=7,
+    )
+
+    assert set(comparison.keys()) == {"static", "dynamic"}
+    for metrics in comparison.values():
+        assert metrics["distance"] == 3
+        assert metrics["rounds"] == 3
+        assert metrics["shots"] == 8
+        assert 0 <= metrics["logical_error_rate"] <= 1
+        assert np.isfinite(metrics["logical_error_rate"])
+
+    rows = list(tabulate_comparison(comparison))
+    assert {row["policy"] for row in rows} == {"static", "dynamic"}
+    for row in rows:
+        assert {"policy", "builder", "logical_error_rate"}.issubset(row.keys())
+        assert np.isfinite(row["logical_error_rate"])
+


### PR DESCRIPTION
This pull request introduces a set of improvements and new utilities to support reinforcement learning (RL) experiments and surface code simulations, with a focus on reproducibility, modularity, and ease of use. Key changes include deterministic seed generation for RL policy comparisons, modular helpers for RL experiments, lazy loading of the optional `stim` dependency, and expanded documentation and testing.

**Reinforcement Learning and Experiment Utilities:**

* Added a new module `rl_experiments.py` providing deterministic seed generation for RL policy comparisons using stable md5 hashes instead of Python's salted `hash`, ensuring reproducibility across runs and platforms.
* Added `surface_code_in_stem/rl_nested_learning.py` with helpers for quickly comparing static and dynamic surface code policies, returning logical error rates and supporting tabular output for downstream analysis.
* Added a new test `tests/test_rl_nested_learning.py` to verify correctness and coverage of the RL helpers, including simulation and tabulation.

**Dependency Management and Modularity:**

* Introduced `rl_nested_learning.py` (at the top level) to provide optional, lazy loading of the `stim` dependency, allowing the module to be imported even if `stim` is not installed, and giving clear installation hints when needed.
* Updated the package's `__init__.py` to expose new RL and surface code helpers in the public API.

**Documentation and Workflow:**

* Added a new section to the `Readme.md` with a quickstart guide for RL experiments, including instructions for installing the optional `stim` dependency and describing the lazy import behavior.
* Added `RL_EXPERIMENTS.md` documenting the new reproducibility features and seed generation approach for RL experiments.
* Introduced a new GitHub Actions workflow `.github/workflows/tests.yml` to automatically install dependencies and run tests on pushes and pull requests.

## Summary by Sourcery

Add deterministic RL experiment helpers, surface code policy comparison utilities, and lazy Stim integration while wiring them into the public API and CI.

New Features:
- Introduce rl_experiments utilities to generate deterministic seeds for nested RL policy configurations.
- Add surface_code_in_stem.rl_nested_learning helpers to simulate and compare static vs dynamic surface-code policies and tabulate results.
- Expose surface code builders and RL comparison helpers from the surface_code_in_stem package’s public API.

Enhancements:
- Implement optional, lazy loading of the Stim dependency via rl_nested_learning to allow importing RL helpers without requiring Stim upfront.

Build:
- Declare Stim as a dependency in requirements.txt to support RL and surface code simulations.

CI:
- Add a GitHub Actions workflow to install core dependencies and run pytest on pushes and pull requests.

Documentation:
- Extend the README with an RL quickstart and Stim installation guidance, and add RL_EXPERIMENTS.md documenting reproducible seed generation for RL experiments.

Tests:
- Add tests for surface_code_in_stem.rl_nested_learning to validate policy comparison outputs and tabulation.