### PR TITLE
Add decoder abstraction package and post-decoding logical error computation

### DIFF
--- a/surface_code_in_stem/decoders/__init__.py
+++ b/surface_code_in_stem/decoders/__init__.py
@@ -1,0 +1,16 @@
+"""Decoder interfaces and adapters for surface-code experiments."""
+
+from .base import DecoderInput, DecoderMetadata, DecoderOutput, DecoderProtocol
+from .mwpm import MWPMDecoder
+from .sparse_blossom import SparseBlossomDecoder
+from .union_find import UnionFindDecoder
+
+__all__ = [
+    "DecoderInput",
+    "DecoderMetadata",
+    "DecoderOutput",
+    "DecoderProtocol",
+    "MWPMDecoder",
+    "UnionFindDecoder",
+    "SparseBlossomDecoder",
+]

--- a/surface_code_in_stem/decoders/base.py
+++ b/surface_code_in_stem/decoders/base.py
@@ -1,0 +1,51 @@
+"""Typed interfaces and containers for detector-event decoders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+BoolArray = NDArray[np.bool_]
+
+
+@dataclass(frozen=True)
+class DecoderMetadata:
+    """Metadata needed by decoders to map detector events to logical predictions."""
+
+    num_observables: int
+    detector_error_model: Any | None = None
+    circuit: Any | None = None
+    seed: int | None = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DecoderInput:
+    """Container for batched detector events and accompanying metadata."""
+
+    detector_events: BoolArray
+    metadata: DecoderMetadata
+
+
+@dataclass(frozen=True)
+class DecoderOutput:
+    """Container for batched predicted logical observables."""
+
+    logical_predictions: BoolArray
+    decoder_name: str
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class DecoderProtocol(Protocol):
+    """Common protocol implemented by all decoder adapters."""
+
+    name: str
+
+    def decode(self, detector_events: BoolArray, metadata: DecoderMetadata) -> DecoderOutput:
+        """Decode detector events into predicted logical observables."""
+        ...

--- a/surface_code_in_stem/decoders/mwpm.py
+++ b/surface_code_in_stem/decoders/mwpm.py
@@ -53,7 +53,8 @@ class MWPMDecoder(DecoderProtocol):
         try:
             logicals = self._decode_with_pymatching(events, metadata)
             backend = "pymatching"
-        except (ImportError, ValueError):
+        except ImportError:
+            # Fallback is only used when the optional pymatching dependency is unavailable.
             logicals = self._fallback_decode(events, metadata)
             backend = "fallback"
 

--- a/surface_code_in_stem/decoders/mwpm.py
+++ b/surface_code_in_stem/decoders/mwpm.py
@@ -1,0 +1,63 @@
+"""Minimum-weight perfect matching decoder adapter.
+
+The adapter prefers PyMatching when available and otherwise falls back to a
+simple deterministic all-zero predictor for environments without optional
+matching dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .base import BoolArray, DecoderMetadata, DecoderOutput, DecoderProtocol
+
+
+@dataclass
+class MWPMDecoder(DecoderProtocol):
+    """MWPM decoder with a PyMatching-compatible detector-error-model path."""
+
+    name: str = "mwpm"
+
+    def _decode_with_pymatching(self, detector_events: BoolArray, metadata: DecoderMetadata) -> BoolArray:
+        """Decode using `pymatching` if the package is installed."""
+
+        try:
+            from pymatching import Matching
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ImportError("pymatching is not installed") from exc
+
+        if metadata.detector_error_model is None:
+            raise ValueError("MWPMDecoder requires detector_error_model in metadata for pymatching path.")
+
+        matching = Matching.from_detector_error_model(metadata.detector_error_model)
+        predictions = matching.decode_batch(detector_events)
+        return np.asarray(predictions, dtype=np.bool_)
+
+    def _fallback_decode(self, detector_events: BoolArray, metadata: DecoderMetadata) -> BoolArray:
+        """Deterministic fallback path when PyMatching is unavailable."""
+
+        shots = int(detector_events.shape[0])
+        return np.zeros((shots, metadata.num_observables), dtype=np.bool_)
+
+    def decode(self, detector_events: BoolArray, metadata: DecoderMetadata) -> DecoderOutput:
+        events = np.asarray(detector_events, dtype=np.bool_)
+        if events.ndim != 2:
+            raise ValueError("detector_events must be a 2D bool array of shape (shots, num_detectors).")
+        if metadata.num_observables <= 0:
+            raise ValueError("metadata.num_observables must be > 0")
+
+        backend: str
+        try:
+            logicals = self._decode_with_pymatching(events, metadata)
+            backend = "pymatching"
+        except (ImportError, ValueError):
+            logicals = self._fallback_decode(events, metadata)
+            backend = "fallback"
+
+        if logicals.shape != (events.shape[0], metadata.num_observables):
+            raise ValueError("Decoder returned predictions with an unexpected shape.")
+
+        return DecoderOutput(logical_predictions=logicals, decoder_name=self.name, diagnostics={"backend": backend})

--- a/surface_code_in_stem/decoders/sparse_blossom.py
+++ b/surface_code_in_stem/decoders/sparse_blossom.py
@@ -1,0 +1,46 @@
+"""Sparse-graph MWPM adapter with graph-pruning hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .base import BoolArray, DecoderMetadata, DecoderOutput, DecoderProtocol
+from .mwpm import MWPMDecoder
+
+GraphPruner = Callable[[Any], Any]
+
+
+@dataclass
+class SparseBlossomDecoder(DecoderProtocol):
+    """Sparse Blossom style decoder wrapper around MWPM infrastructure."""
+
+    graph_pruner: GraphPruner | None = None
+    name: str = "sparse_blossom"
+
+    def __post_init__(self) -> None:
+        self._delegate = MWPMDecoder(name=self.name)
+
+    def _maybe_prune_metadata(self, metadata: DecoderMetadata) -> DecoderMetadata:
+        if self.graph_pruner is None or metadata.detector_error_model is None:
+            return metadata
+
+        pruned_dem = self.graph_pruner(metadata.detector_error_model)
+        return DecoderMetadata(
+            num_observables=metadata.num_observables,
+            detector_error_model=pruned_dem,
+            circuit=metadata.circuit,
+            seed=metadata.seed,
+            extra=metadata.extra,
+        )
+
+    def decode(self, detector_events: BoolArray, metadata: DecoderMetadata) -> DecoderOutput:
+        pruned_metadata = self._maybe_prune_metadata(metadata)
+        output = self._delegate.decode(detector_events=detector_events, metadata=pruned_metadata)
+        diagnostics = dict(output.diagnostics)
+        diagnostics["graph_pruned"] = self.graph_pruner is not None
+        return DecoderOutput(
+            logical_predictions=output.logical_predictions,
+            decoder_name=self.name,
+            diagnostics=diagnostics,
+        )

--- a/surface_code_in_stem/decoders/union_find.py
+++ b/surface_code_in_stem/decoders/union_find.py
@@ -1,8 +1,9 @@
 """Union-Find decoder adapter.
 
-This adapter uses the same PyMatching detector-error-model interface where
-available and exposes a separate decoder identity for experiments comparing
-near-linear-time decoders.
+This is currently an experiment-facing placeholder that delegates to the MWPM
+implementation while preserving a distinct decoder identity and diagnostics.
+It exists so comparison code can wire in a future union-find decoder without
+changing the surrounding interface.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from .mwpm import MWPMDecoder
 
 @dataclass
 class UnionFindDecoder(DecoderProtocol):
-    """Union-Find-style adapter with deterministic fallback behavior."""
+    """Placeholder union-find adapter that currently delegates to MWPM."""
 
     name: str = "union_find"
 

--- a/surface_code_in_stem/decoders/union_find.py
+++ b/surface_code_in_stem/decoders/union_find.py
@@ -1,0 +1,33 @@
+"""Union-Find decoder adapter.
+
+This adapter uses the same PyMatching detector-error-model interface where
+available and exposes a separate decoder identity for experiments comparing
+near-linear-time decoders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import BoolArray, DecoderMetadata, DecoderOutput, DecoderProtocol
+from .mwpm import MWPMDecoder
+
+
+@dataclass
+class UnionFindDecoder(DecoderProtocol):
+    """Union-Find-style adapter with deterministic fallback behavior."""
+
+    name: str = "union_find"
+
+    def __post_init__(self) -> None:
+        self._delegate = MWPMDecoder(name=self.name)
+
+    def decode(self, detector_events: BoolArray, metadata: DecoderMetadata) -> DecoderOutput:
+        output = self._delegate.decode(detector_events=detector_events, metadata=metadata)
+        diagnostics = dict(output.diagnostics)
+        diagnostics["algorithm"] = "union_find_adapter"
+        return DecoderOutput(
+            logical_predictions=output.logical_predictions,
+            decoder_name=self.name,
+            diagnostics=diagnostics,
+        )

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -51,8 +51,18 @@ def _logical_error_rate(
 
     # Post-decoding logical error is the residual mismatch between decoder
     # predictions and the sampled observable values.
-    logical_mismatch = np.logical_xor(decoded.logical_predictions, observable_samples)
+    logical_predictions = np.asarray(decoded.logical_predictions)
 
+    if logical_predictions.shape != observable_samples.shape:
+        raise ValueError(
+            f"Decoder returned logical_predictions with shape {logical_predictions.shape}, "
+            f"but expected {observable_samples.shape} to match observable_samples."
+        )
+
+    if logical_predictions.dtype != observable_samples.dtype:
+        logical_predictions = logical_predictions.astype(observable_samples.dtype, copy=False)
+
+    logical_mismatch = np.logical_xor(logical_predictions, observable_samples)
     return float(np.mean(logical_mismatch[:, 0]))
 
 

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -13,14 +13,20 @@ from typing import Callable, Dict, Iterable
 import numpy as np
 
 from surface_code_in_stem.dynamic import hexagonal_surface_code
+from surface_code_in_stem.decoders import DecoderMetadata, DecoderProtocol, MWPMDecoder
 from surface_code_in_stem.surface_code import surface_code_circuit_string
 
 
 StimBuilder = Callable[[int, int, float], str]
 
 
-def _logical_error_rate(circuit_string: str, shots: int, seed: int | None) -> float:
-    """Estimate logical observable-0 failure probability across sampled shots."""
+def _logical_error_rate(
+    circuit_string: str,
+    shots: int,
+    seed: int | None,
+    decoder: DecoderProtocol | None = None,
+) -> float:
+    """Estimate post-decoding logical-observable-0 error probability."""
 
     try:
         import stim
@@ -32,10 +38,22 @@ def _logical_error_rate(circuit_string: str, shots: int, seed: int | None) -> fl
         raise ValueError("Circuit must define observable 0 to estimate logical error rate.")
 
     sampler = circuit.compile_detector_sampler(seed=seed)
-    _, observable_samples = sampler.sample(shots, separate_observables=True)
+    detector_samples, observable_samples = sampler.sample(shots, separate_observables=True)
 
-    # Logical error rate is the probability that logical observable 0 flips.
-    return float(np.mean(observable_samples[:, 0]))
+    active_decoder = decoder or MWPMDecoder()
+    metadata = DecoderMetadata(
+        num_observables=circuit.num_observables,
+        detector_error_model=circuit.detector_error_model(decompose_errors=True),
+        circuit=circuit,
+        seed=seed,
+    )
+    decoded = active_decoder.decode(detector_samples, metadata=metadata)
+
+    # Post-decoding logical error is the residual mismatch between decoder
+    # predictions and the sampled observable values.
+    logical_mismatch = np.logical_xor(decoded.logical_predictions, observable_samples)
+
+    return float(np.mean(logical_mismatch[:, 0]))
 
 
 def compare_nested_policies(

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -43,10 +43,12 @@ def _logical_error_rate(
     active_decoder = decoder or MWPMDecoder()
     metadata = DecoderMetadata(
         num_observables=circuit.num_observables,
-        detector_error_model=circuit.detector_error_model(decompose_errors=True),
+        detector_error_model=None,
         circuit=circuit,
         seed=seed,
     )
+    if isinstance(active_decoder, MWPMDecoder):
+        metadata.detector_error_model = circuit.detector_error_model(decompose_errors=True)
     decoded = active_decoder.decode(detector_samples, metadata=metadata)
 
     # Post-decoding logical error is the residual mismatch between decoder

--- a/surface_code_in_stem/rl_nested_learning.py
+++ b/surface_code_in_stem/rl_nested_learning.py
@@ -8,6 +8,7 @@ without requiring long simulation times.
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import Callable, Dict, Iterable
 
 import numpy as np
@@ -47,7 +48,7 @@ def _logical_error_rate(
         circuit=circuit,
         seed=seed,
     )
-    if isinstance(active_decoder, MWPMDecoder):
+    if isinstance(active_decoder, MWPMDecoder) and find_spec("pymatching") is not None:
         metadata.detector_error_model = circuit.detector_error_model(decompose_errors=True)
     decoded = active_decoder.decode(detector_samples, metadata=metadata)
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -38,6 +38,16 @@ def test_mwpm_decoder_output_is_deterministic_for_fixed_inputs():
     np.testing.assert_array_equal(first, second)
 
 
+def test_mwpm_decoder_reports_pymatching_backend_when_available():
+    pytest.importorskip("pymatching")
+
+    detector_samples, observable_samples, metadata = _sample_detector_data(shots=32, p=0.01)
+    output = MWPMDecoder().decode(detector_samples, metadata)
+
+    assert output.diagnostics["backend"] == "pymatching"
+    assert output.logical_predictions.shape == observable_samples.shape
+
+
 def test_union_find_and_sparse_blossom_match_mwpm_on_small_circuit():
     detector_samples, _, metadata = _sample_detector_data()
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -1,0 +1,58 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+stim = pytest.importorskip("stim")
+
+from surface_code_in_stem.decoders import (
+    DecoderMetadata,
+    MWPMDecoder,
+    SparseBlossomDecoder,
+    UnionFindDecoder,
+)
+from surface_code_in_stem.rl_nested_learning import _logical_error_rate
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+
+def _sample_detector_data(*, distance: int = 3, rounds: int = 2, p: float = 0.001, shots: int = 12, seed: int = 99):
+    circuit = stim.Circuit(surface_code_circuit_string(distance, rounds, p))
+    detector_samples, observable_samples = circuit.compile_detector_sampler(seed=seed).sample(
+        shots=shots,
+        separate_observables=True,
+    )
+    metadata = DecoderMetadata(
+        num_observables=circuit.num_observables,
+        detector_error_model=circuit.detector_error_model(decompose_errors=True),
+        circuit=circuit,
+        seed=seed,
+    )
+    return detector_samples, observable_samples, metadata
+
+
+def test_mwpm_decoder_output_is_deterministic_for_fixed_inputs():
+    detector_samples, _, metadata = _sample_detector_data()
+    decoder = MWPMDecoder()
+
+    first = decoder.decode(detector_samples, metadata).logical_predictions
+    second = decoder.decode(detector_samples, metadata).logical_predictions
+
+    np.testing.assert_array_equal(first, second)
+
+
+def test_union_find_and_sparse_blossom_match_mwpm_on_small_circuit():
+    detector_samples, _, metadata = _sample_detector_data()
+
+    mwpm_predictions = MWPMDecoder().decode(detector_samples, metadata).logical_predictions
+    union_find_predictions = UnionFindDecoder().decode(detector_samples, metadata).logical_predictions
+    sparse_predictions = SparseBlossomDecoder().decode(detector_samples, metadata).logical_predictions
+
+    np.testing.assert_array_equal(union_find_predictions, mwpm_predictions)
+    np.testing.assert_array_equal(sparse_predictions, mwpm_predictions)
+
+
+def test_logical_error_rate_with_decoder_is_seed_deterministic():
+    circuit_string = surface_code_circuit_string(3, 3, 0.001)
+
+    first = _logical_error_rate(circuit_string, shots=16, seed=123, decoder=MWPMDecoder())
+    second = _logical_error_rate(circuit_string, shots=16, seed=123, decoder=MWPMDecoder())
+
+    assert first == second


### PR DESCRIPTION
### Motivation
- Provide a pluggable decoder abstraction and a small set of decoder adapters to enable fair comparisons and to compute logical error rates after decoding.

### Description
- Added a new `surface_code_in_stem/decoders/` package and `base.py` that defines `DecoderProtocol`, `DecoderMetadata`, `DecoderInput`, and `DecoderOutput` dataclasses.
- Implemented `MWPMDecoder` (`mwpm.py`) with a PyMatching-compatible path (`Matching.from_detector_error_model(...).decode_batch(...)`) and a deterministic fallback when optional dependencies are unavailable.
- Added `UnionFindDecoder` (`union_find.py`) as an adapter that preserves a distinct decoder identity and diagnostics while delegating to the MWPM path, and `SparseBlossomDecoder` (`sparse_blossom.py`) that accepts a `graph_pruner` hook to transform detector-error-model metadata before decoding.
- Refactored `_logical_error_rate` in `surface_code_in_stem/rl_nested_learning.py` to sample detector events with `separate_observables=True`, decode sampled detector events via a `DecoderProtocol` (defaulting to `MWPMDecoder`), and compute the post-decoding logical error rate as the XOR between decoded logicals and sampled observables.

### Testing
- Ran `pytest -q` in this environment which skipped tests due to optional runtime dependencies (tests use `pytest.importorskip` for `numpy`/`stim`/`pymatching`) resulting in skipped tests.
- Compiled the package and tests with `python -m compileall surface_code_in_stem tests`, which succeeded.
- Added `tests/test_decoders.py` that checks deterministic outputs for `MWPMDecoder`, parity of `UnionFindDecoder` and `SparseBlossomDecoder` with the MWPM baseline on small circuits, and seed-determinism of the new `_logical_error_rate` flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06614fbf48328b5e440605cee212d)

## Summary by Sourcery

Introduce a pluggable decoder abstraction and use it to compute post-decoding logical error rates in nested RL experiments.

New Features:
- Add a decoders package defining shared decoder protocols and metadata containers for detector-event decoding.
- Provide MWPM, UnionFind, and Sparse Blossom decoder adapters built on a common interface with deterministic fallback behavior.
- Allow the logical error rate computation in rl_nested_learning to accept a configurable decoder and use detector samples for post-decoding logical error estimation.

Tests:
- Add tests validating MWPM decoder determinism, parity of UnionFind and Sparse Blossom decoders with MWPM on small circuits, and seed-determinism of the updated logical error rate computation.