### PR TITLE
Add RL control module for calibration and steering

### DIFF
--- a/surface_code_in_stem/__init__.py
+++ b/surface_code_in_stem/__init__.py
@@ -9,6 +9,13 @@ from .dynamic_surface_codes import (
     walking_surface_code,
 )
 from .rl_nested_learning import compare_nested_policies, tabulate_comparison
+from .rl_control import (
+    PEPGOptimizer,
+    StimCalibrationConfig,
+    StimCalibrationEnvironment,
+    TrainingConfig,
+    run_simulator_training,
+)
 
 __all__ = [
     "surface_code_circuit_string",
@@ -19,5 +26,10 @@ __all__ = [
     "walking_surface_code",
     "compare_nested_policies",
     "tabulate_comparison",
+    "StimCalibrationConfig",
+    "StimCalibrationEnvironment",
+    "PEPGOptimizer",
+    "TrainingConfig",
+    "run_simulator_training",
 ]
 

--- a/surface_code_in_stem/rl_control/__init__.py
+++ b/surface_code_in_stem/rl_control/__init__.py
@@ -1,0 +1,30 @@
+"""RL control module for calibration and steering."""
+
+from .environment import (
+    ControlEnvironment,
+    HardwareTraceAdapter,
+    StimCalibrationConfig,
+    StimCalibrationEnvironment,
+)
+from .masking import (
+    apply_masked_detector_weights,
+    build_detector_parameter_mask,
+    mask_population_perturbations,
+    parameter_neighborhoods,
+)
+from .optimizer import PEPGOptimizer
+from .training import TrainingConfig, run_simulator_training
+
+__all__ = [
+    "ControlEnvironment",
+    "HardwareTraceAdapter",
+    "StimCalibrationConfig",
+    "StimCalibrationEnvironment",
+    "PEPGOptimizer",
+    "TrainingConfig",
+    "run_simulator_training",
+    "build_detector_parameter_mask",
+    "parameter_neighborhoods",
+    "apply_masked_detector_weights",
+    "mask_population_perturbations",
+]

--- a/surface_code_in_stem/rl_control/environment.py
+++ b/surface_code_in_stem/rl_control/environment.py
@@ -1,0 +1,126 @@
+"""Environment abstractions for RL-based calibration and steering.
+
+Observation vectors are detector statistics (e.g., detector click rates), while
+actions are perturbations applied to a control-parameter vector.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+
+class ControlEnvironment(Protocol):
+    """Protocol for calibration environments.
+
+    Implementations should expose detector-statistic observations and accept
+    action vectors representing control-parameter perturbations.
+    """
+
+    action_dim: int
+
+    def reset(self) -> np.ndarray:
+        """Reset the environment and return the initial observation."""
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, dict[str, float]]:
+        """Apply an action, return (observation, reward, diagnostics)."""
+
+
+@dataclass(frozen=True)
+class StimCalibrationConfig:
+    """Configuration for a Stim-backed calibration environment."""
+
+    distance: int = 3
+    rounds: int = 3
+    shots: int = 128
+    base_error_rate: float = 0.001
+    seed: int = 0
+
+
+class StimCalibrationEnvironment:
+    """Stim-backed environment for policy calibration.
+
+    The environment maintains a parameter vector ``theta``. Each action is added
+    to ``theta``. The effective circuit error rate is computed as
+    ``clip(base_error_rate + theta.sum(), 1e-6, 0.2)``.
+    """
+
+    def __init__(self, config: StimCalibrationConfig, parameter_dim: int = 4):
+        if parameter_dim <= 0:
+            raise ValueError("parameter_dim must be positive.")
+        self.config = config
+        self.action_dim = parameter_dim
+        self._rng = np.random.default_rng(config.seed)
+        self.theta = np.zeros(parameter_dim, dtype=np.float64)
+
+    def _build_sampler(self, physical_error_rate: float):
+        try:
+            import stim
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise ImportError("Stim is required for StimCalibrationEnvironment.") from exc
+
+        circuit_text = surface_code_circuit_string(
+            self.config.distance,
+            self.config.rounds,
+            float(physical_error_rate),
+        )
+        circuit = stim.Circuit(circuit_text)
+        sampler = circuit.compile_detector_sampler(seed=self.config.seed)
+        return sampler
+
+    def _evaluate(self) -> tuple[np.ndarray, float, dict[str, float]]:
+        physical_error_rate = float(
+            np.clip(self.config.base_error_rate + np.sum(self.theta), 1e-6, 0.2)
+        )
+        sampler = self._build_sampler(physical_error_rate)
+        det_samples, obs_samples = sampler.sample(
+            self.config.shots,
+            separate_observables=True,
+        )
+        detector_rates = np.mean(det_samples, axis=0, dtype=np.float64)
+        logical_error_rate = float(np.mean(obs_samples[:, 0], dtype=np.float64))
+        reward = -logical_error_rate
+        diagnostics = {
+            "logical_error_rate": logical_error_rate,
+            "effective_p": physical_error_rate,
+        }
+        return detector_rates, reward, diagnostics
+
+    def reset(self) -> np.ndarray:
+        self.theta.fill(0.0)
+        observation, _, _ = self._evaluate()
+        return observation
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, dict[str, float]]:
+        action = np.asarray(action, dtype=np.float64)
+        if action.shape != (self.action_dim,):
+            raise ValueError(f"action must have shape ({self.action_dim},).")
+        self.theta = np.clip(self.theta + action, -0.05, 0.05)
+        return self._evaluate()
+
+
+class HardwareTraceAdapter:
+    """Adapter hooks for future hardware trace integration.
+
+    Users should subclass this and implement trace acquisition plus reward
+    extraction from experiment metadata.
+    """
+
+    def observation_from_trace(self, trace: np.ndarray) -> np.ndarray:
+        """Convert raw hardware traces to detector-statistic observations."""
+        trace = np.asarray(trace, dtype=np.float64)
+        if trace.ndim != 2:
+            raise ValueError("trace must be a 2D array [shots, detectors].")
+        return np.mean(trace, axis=0)
+
+    def reward_from_trace(self, trace: np.ndarray) -> float:
+        """Compute reward from hardware trace.
+
+        Placeholder implementation minimizes total detector activity.
+        """
+        obs = self.observation_from_trace(trace)
+        return -float(np.mean(obs))

--- a/surface_code_in_stem/rl_control/evaluation/__init__.py
+++ b/surface_code_in_stem/rl_control/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation entry points for RL calibration/steering experiments."""

--- a/surface_code_in_stem/rl_control/evaluation/drift_steering.py
+++ b/surface_code_in_stem/rl_control/evaluation/drift_steering.py
@@ -1,0 +1,44 @@
+"""Evaluation script: drift steering under synthetic sinusoidal/step drifts."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from surface_code_in_stem.rl_control.environment import StimCalibrationConfig, StimCalibrationEnvironment
+from surface_code_in_stem.rl_control.optimizer import PEPGOptimizer
+from surface_code_in_stem.rl_control.training import TrainingConfig, run_simulator_training
+
+
+def run(kind: str = "sin", generations: int = 10) -> list[dict[str, float]]:
+    config = StimCalibrationConfig(seed=7)
+    env = StimCalibrationEnvironment(config, parameter_dim=4)
+    optimizer = PEPGOptimizer(parameter_dim=4, seed=7)
+    history: list[dict[str, float]] = []
+
+    for t in range(generations):
+        if kind == "sin":
+            env.config = StimCalibrationConfig(
+                **{**env.config.__dict__, "base_error_rate": 0.001 + 0.0005 * np.sin(0.25 * t)}
+            )
+        elif kind == "step":
+            bump = 0.001 if t >= generations // 2 else 0.0
+            env.config = StimCalibrationConfig(
+                **{**env.config.__dict__, "base_error_rate": 0.001 + bump}
+            )
+        else:
+            raise ValueError("kind must be 'sin' or 'step'.")
+
+        cfg = TrainingConfig(generations=1, population_size=20, checkpoint_every=999)
+        history.extend(run_simulator_training(env, optimizer, config=cfg))
+    return history
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kind", choices=["sin", "step"], default="sin")
+    parser.add_argument("--generations", type=int, default=10)
+    args = parser.parse_args()
+    metrics = run(kind=args.kind, generations=args.generations)
+    print(metrics[-1])

--- a/surface_code_in_stem/rl_control/evaluation/fine_tuning.py
+++ b/surface_code_in_stem/rl_control/evaluation/fine_tuning.py
@@ -1,0 +1,25 @@
+"""Evaluation script: fine-tune from a calibrated policy checkpoint."""
+
+from __future__ import annotations
+
+from surface_code_in_stem.rl_control.environment import StimCalibrationConfig, StimCalibrationEnvironment
+from surface_code_in_stem.rl_control.optimizer import PEPGOptimizer
+from surface_code_in_stem.rl_control.training import TrainingConfig, run_simulator_training
+
+
+def run(checkpoint_path: str, generations: int = 10) -> list[dict[str, float]]:
+    env = StimCalibrationEnvironment(StimCalibrationConfig(seed=123), parameter_dim=4)
+    optimizer = PEPGOptimizer.load_checkpoint(checkpoint_path)
+    cfg = TrainingConfig(generations=generations, population_size=20, checkpoint_every=generations + 1)
+    return run_simulator_training(env, optimizer, config=cfg)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint", type=str)
+    parser.add_argument("--generations", type=int, default=10)
+    args = parser.parse_args()
+    metrics = run(args.checkpoint, generations=args.generations)
+    print(metrics[-1])

--- a/surface_code_in_stem/rl_control/evaluation/recovery_random_init.py
+++ b/surface_code_in_stem/rl_control/evaluation/recovery_random_init.py
@@ -1,0 +1,31 @@
+"""Evaluation script: recovery from randomized initialization."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from surface_code_in_stem.rl_control.environment import StimCalibrationConfig, StimCalibrationEnvironment
+from surface_code_in_stem.rl_control.optimizer import PEPGOptimizer
+from surface_code_in_stem.rl_control.training import TrainingConfig, run_simulator_training
+
+
+def run(trials: int = 3, generations: int = 10) -> list[list[dict[str, float]]]:
+    all_histories: list[list[dict[str, float]]] = []
+    for seed in range(trials):
+        env = StimCalibrationEnvironment(StimCalibrationConfig(seed=seed), parameter_dim=4)
+        optimizer = PEPGOptimizer(parameter_dim=4, seed=seed)
+        optimizer.mean = np.random.default_rng(seed).uniform(-0.03, 0.03, size=4)
+        cfg = TrainingConfig(generations=generations, population_size=20, checkpoint_every=999)
+        all_histories.append(run_simulator_training(env, optimizer, config=cfg))
+    return all_histories
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--generations", type=int, default=10)
+    args = parser.parse_args()
+    out = run(trials=args.trials, generations=args.generations)
+    print({"trials": len(out), "last": out[-1][-1]})

--- a/surface_code_in_stem/rl_control/masking.py
+++ b/surface_code_in_stem/rl_control/masking.py
@@ -1,0 +1,74 @@
+"""Factor-graph masking utilities for local detector-parameter neighborhoods."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+import numpy as np
+
+
+def build_detector_parameter_mask(
+    num_detectors: int,
+    num_parameters: int,
+    edges: Iterable[tuple[int, int]],
+) -> np.ndarray:
+    """Build a binary detector-parameter adjacency mask.
+
+    Args:
+        num_detectors: Number of detector nodes.
+        num_parameters: Number of control-parameter nodes.
+        edges: Iterable of (detector_idx, parameter_idx).
+    """
+    mask = np.zeros((num_detectors, num_parameters), dtype=np.float64)
+    for det_idx, param_idx in edges:
+        if not (0 <= det_idx < num_detectors):
+            raise ValueError("detector index out of range")
+        if not (0 <= param_idx < num_parameters):
+            raise ValueError("parameter index out of range")
+        mask[det_idx, param_idx] = 1.0
+    return mask
+
+
+def parameter_neighborhoods(mask: np.ndarray) -> dict[int, np.ndarray]:
+    """Return detector neighborhoods for each parameter."""
+    mask = np.asarray(mask, dtype=np.float64)
+    if mask.ndim != 2:
+        raise ValueError("mask must be a 2D array")
+    neighborhoods = defaultdict(list)
+    for det_idx, param_idx in np.argwhere(mask > 0):
+        neighborhoods[int(param_idx)].append(int(det_idx))
+    return {k: np.asarray(v, dtype=np.int64) for k, v in neighborhoods.items()}
+
+
+def apply_masked_detector_weights(
+    detector_signal: np.ndarray,
+    mask: np.ndarray,
+    normalize: bool = True,
+) -> np.ndarray:
+    """Aggregate detector signals into parameter-wise masked signals."""
+    detector_signal = np.asarray(detector_signal, dtype=np.float64)
+    mask = np.asarray(mask, dtype=np.float64)
+    if detector_signal.ndim != 1:
+        raise ValueError("detector_signal must be a vector")
+    if mask.ndim != 2:
+        raise ValueError("mask must be a matrix")
+    if mask.shape[0] != detector_signal.shape[0]:
+        raise ValueError("mask rows must match detector_signal length")
+
+    weighted = mask.T @ detector_signal
+    if not normalize:
+        return weighted
+    degree = np.maximum(np.sum(mask, axis=0), 1.0)
+    return weighted / degree
+
+
+def mask_population_perturbations(
+    perturbations: np.ndarray,
+    detector_signal: np.ndarray,
+    mask: np.ndarray,
+) -> np.ndarray:
+    """Variance-reducing mask: gate perturbation columns by local detector activity."""
+    perturbations = np.asarray(perturbations, dtype=np.float64)
+    param_weights = apply_masked_detector_weights(detector_signal, mask, normalize=True)
+    return perturbations * param_weights[None, :]

--- a/surface_code_in_stem/rl_control/optimizer.py
+++ b/surface_code_in_stem/rl_control/optimizer.py
@@ -1,0 +1,122 @@
+"""PEPG-style optimizer for policy search over control parameters."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import json
+
+import numpy as np
+
+
+@dataclass
+class PEPGState:
+    """Serializable optimizer state."""
+
+    mean: list[float]
+    sigma: list[float]
+    learning_rate: float
+    sigma_learning_rate: float
+    iteration: int
+    seed: int
+    rng_state: dict
+
+
+class PEPGOptimizer:
+    """Parameter-Exploring Policy Gradients (PEPG) with diagonal Gaussian."""
+
+    def __init__(
+        self,
+        parameter_dim: int,
+        *,
+        seed: int = 0,
+        init_sigma: float = 0.1,
+        learning_rate: float = 0.05,
+        sigma_learning_rate: float = 0.02,
+        sigma_min: float = 1e-4,
+    ):
+        if parameter_dim <= 0:
+            raise ValueError("parameter_dim must be positive")
+        self.parameter_dim = parameter_dim
+        self.mean = np.zeros(parameter_dim, dtype=np.float64)
+        self.sigma = np.full(parameter_dim, init_sigma, dtype=np.float64)
+        self.learning_rate = float(learning_rate)
+        self.sigma_learning_rate = float(sigma_learning_rate)
+        self.sigma_min = float(sigma_min)
+        self.iteration = 0
+        self.seed = int(seed)
+        self._rng = np.random.default_rng(self.seed)
+
+    def ask(self, population_size: int) -> tuple[np.ndarray, np.ndarray]:
+        """Sample antithetic population and return (candidates, perturbations)."""
+        if population_size <= 0 or population_size % 2 != 0:
+            raise ValueError("population_size must be a positive even integer")
+        half = population_size // 2
+        eps = self._rng.standard_normal((half, self.parameter_dim))
+        perturb = np.vstack([eps, -eps]) * self.sigma
+        candidates = self.mean + perturb
+        return candidates, perturb
+
+    def tell(self, perturbations: np.ndarray, rewards: np.ndarray) -> None:
+        """Update mean and sigma from population rewards."""
+        perturbations = np.asarray(perturbations, dtype=np.float64)
+        rewards = np.asarray(rewards, dtype=np.float64)
+        if perturbations.shape[0] != rewards.shape[0]:
+            raise ValueError("perturbations and rewards length mismatch")
+
+        centered = rewards - np.mean(rewards)
+        scale = np.std(rewards)
+        if scale > 0:
+            centered = centered / (scale + 1e-8)
+
+        grad_mean = perturbations.T @ centered / len(rewards)
+        self.mean += self.learning_rate * grad_mean
+
+        sigma_grad = (
+            ((perturbations**2 - self.sigma**2) / np.maximum(self.sigma, 1e-8)).T
+            @ centered
+            / len(rewards)
+        )
+        self.sigma = np.maximum(self.sigma + self.sigma_learning_rate * sigma_grad, self.sigma_min)
+        self.iteration += 1
+
+    def state_dict(self) -> PEPGState:
+        """Return serializable state."""
+        return PEPGState(
+            mean=self.mean.tolist(),
+            sigma=self.sigma.tolist(),
+            learning_rate=self.learning_rate,
+            sigma_learning_rate=self.sigma_learning_rate,
+            iteration=self.iteration,
+            seed=self.seed,
+            rng_state=self._rng.bit_generator.state,
+        )
+
+    def load_state_dict(self, state: PEPGState) -> None:
+        """Load optimizer from state."""
+        self.mean = np.asarray(state.mean, dtype=np.float64)
+        self.sigma = np.asarray(state.sigma, dtype=np.float64)
+        self.learning_rate = state.learning_rate
+        self.sigma_learning_rate = state.sigma_learning_rate
+        self.iteration = state.iteration
+        self.seed = state.seed
+        self._rng = np.random.default_rng()
+        self._rng.bit_generator.state = state.rng_state
+
+    def save_checkpoint(self, path: str | Path) -> None:
+        """Persist optimizer checkpoint as JSON."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(asdict(self.state_dict()), f, indent=2)
+
+    @classmethod
+    def load_checkpoint(cls, path: str | Path) -> "PEPGOptimizer":
+        """Restore optimizer from checkpoint."""
+        path = Path(path)
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+        state = PEPGState(**payload)
+        opt = cls(parameter_dim=len(state.mean), seed=state.seed)
+        opt.load_state_dict(state)
+        return opt

--- a/surface_code_in_stem/rl_control/training.py
+++ b/surface_code_in_stem/rl_control/training.py
@@ -1,0 +1,62 @@
+"""Training loops for simulator-backed and hardware-adapted control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .environment import ControlEnvironment
+from .masking import mask_population_perturbations
+from .optimizer import PEPGOptimizer
+
+
+@dataclass
+class TrainingConfig:
+    generations: int = 20
+    population_size: int = 20
+    checkpoint_every: int = 5
+    checkpoint_dir: str = "checkpoints/rl_control"
+
+
+def run_simulator_training(
+    env: ControlEnvironment,
+    optimizer: PEPGOptimizer,
+    *,
+    config: TrainingConfig,
+    mask: np.ndarray | None = None,
+) -> list[dict[str, float]]:
+    """Run PEPG loop against a calibration environment."""
+    history: list[dict[str, float]] = []
+    observation = env.reset()
+
+    for generation in range(config.generations):
+        candidates, perturbations = optimizer.ask(config.population_size)
+        rewards = np.zeros(config.population_size, dtype=np.float64)
+
+        for idx in range(config.population_size):
+            action = candidates[idx] - optimizer.mean
+            _, reward, _ = env.step(action)
+            rewards[idx] = reward
+
+        used_perturb = perturbations
+        if mask is not None:
+            used_perturb = mask_population_perturbations(perturbations, observation, mask)
+
+        optimizer.tell(used_perturb, rewards)
+        observation = env.reset()
+
+        metrics = {
+            "generation": float(generation),
+            "reward_mean": float(np.mean(rewards)),
+            "reward_max": float(np.max(rewards)),
+            "sigma_mean": float(np.mean(optimizer.sigma)),
+        }
+        history.append(metrics)
+
+        if (generation + 1) % config.checkpoint_every == 0:
+            ckpt = Path(config.checkpoint_dir) / f"pepg_gen_{generation + 1}.json"
+            optimizer.save_checkpoint(ckpt)
+
+    return history

--- a/tests/test_rl_control.py
+++ b/tests/test_rl_control.py
@@ -1,0 +1,37 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from surface_code_in_stem.rl_control.masking import (
+    apply_masked_detector_weights,
+    build_detector_parameter_mask,
+    mask_population_perturbations,
+)
+from surface_code_in_stem.rl_control.optimizer import PEPGOptimizer
+
+
+def test_pepg_optimizer_updates_towards_higher_reward_direction():
+    opt = PEPGOptimizer(parameter_dim=2, seed=11, init_sigma=0.2, learning_rate=0.2)
+    candidates, perturb = opt.ask(10)
+
+    # Reward aligned with +x direction should push mean[0] upward.
+    rewards = candidates[:, 0]
+    initial = opt.mean.copy()
+    opt.tell(perturb, rewards)
+
+    assert opt.mean[0] > initial[0]
+    assert np.isfinite(opt.mean).all()
+    assert np.all(opt.sigma > 0)
+
+
+def test_mask_application_on_toy_factor_graph():
+    # detector 0 -> param 0, detector 1 -> params 0 and 1
+    mask = build_detector_parameter_mask(3, 2, edges=[(0, 0), (1, 0), (1, 1)])
+    detector_signal = np.array([1.0, 0.5, 0.0])
+
+    weights = apply_masked_detector_weights(detector_signal, mask, normalize=True)
+    np.testing.assert_allclose(weights, np.array([0.75, 0.5]))
+
+    perturb = np.array([[1.0, 2.0], [-1.0, 1.0]])
+    masked = mask_population_perturbations(perturb, detector_signal, mask)
+    np.testing.assert_allclose(masked, np.array([[0.75, 1.0], [-0.75, 0.5]]))


### PR DESCRIPTION
### Motivation

- Provide a focused RL submodule for calibrating/steering control parameters where observations are detector statistics and actions are parameter perturbations for surface-code experiments.
- Include a deterministic, checkpointable black-box optimizer for low-sample policy search usable with Stim-based simulator rewards and future hardware traces.
- Reduce gradient variance by masking population perturbations using local detector-to-parameter neighborhoods.

### Description

- Added `surface_code_in_stem/rl_control/` with an environment abstraction `ControlEnvironment` and a Stim-backed `StimCalibrationEnvironment` plus `HardwareTraceAdapter` hooks for hardware traces (`environment.py`).
- Implemented a PEPG-style optimizer `PEPGOptimizer` with antithetic Gaussian sampling, mean/sigma updates, deterministic RNG, and JSON checkpoint save/load including RNG state (`optimizer.py`).
- Added factor-graph masking utilities to build adjacency masks, extract parameter neighborhoods, aggregate detector weights, and apply masked perturbations for variance reduction (`masking.py`).
- Implemented a simulator-backed PEPG training loop with optional masking and periodic checkpointing (`training.py`), and evaluation entry points for fine-tuning, drift steering (sinusoidal/step), and recovery from random initialization (`evaluation/*.py`).
- Exposed key APIs via `surface_code_in_stem/rl_control/__init__.py` and re-exported important symbols from the package root (`surface_code_in_stem/__init__.py`).
- Added unit tests for optimizer update behavior and mask application on toy factor graphs (`tests/test_rl_control.py`).

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_rl_control.py` and the new control tests passed (2 passed).
- Executed `PYTHONPATH=. pytest -q tests/test_rl_nested_learning.py` which was skipped in this environment because `stim` is not available (no failures from the new code).
- Compiled the package with `python -m compileall surface_code_in_stem tests` to validate imports and byte-compilation (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0661864cc8328ada2c452eaa7f159)

## Summary by Sourcery

Introduce a reusable RL control submodule for Stim-backed surface-code calibration and steering, including environments, optimizer, masking utilities, and training loops, and expose its main APIs at the package root.

New Features:
- Add Stim-backed calibration environment and hardware-trace adapter abstraction for RL-based control.
- Provide a PEPG-based black-box optimizer with JSON checkpointing for policy search over control parameters.
- Add factor-graph-based masking utilities to map detector activity to parameter-wise weights for variance-reduced updates.
- Implement simulator-backed training loop and evaluation entry points for fine-tuning, drift steering, and recovery from random initialization.

Tests:
- Add unit tests covering PEPG optimizer update behavior and masking on a toy factor graph.