### PR TITLE
Refactor into code-family plugins with shared benchmark API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,12 @@ This repository contains implementations and simulations of quantum error correc
 ## Structure
 - `introduction_to_stim/`: Lab exercises and tutorials for Stim
 - `surface_code_in_stem/`: Surface code implementation and simulations
+- `codes/`: Code-family plugin system with shared interfaces and a benchmark harness
+  to evaluate multiple families through the same decoder API.
+  - `codes/surface/`: Surface-code plugin + compatibility wrappers around existing builders
+  - `codes/qldpc/`: qLDPC placeholder plugin with explicit parity-check schema
+  - `codes/bosonic/`: Bosonic placeholder plugin scaffold
+  - `codes/dual_rail_erasure/`: Dual-rail erasure placeholder plugin with required parity inputs
 - `surface_code_in_stem/dynamic/`: Stim circuit builders for the hexagonal,
   walking, and iSWAP dynamic surface codes demonstrated in Morvan et al.
   (Nature Physics, 2025). See `surface_code_in_stem/DYNAMIC_CODES.md` for a

--- a/codes/__init__.py
+++ b/codes/__init__.py
@@ -1,0 +1,37 @@
+"""Code-family plugin package for shared circuit/decoder workflows."""
+
+from .benchmark import benchmark_code_families, default_stim_decoder_evaluator
+from .interfaces import (
+    CircuitGenerationConfig,
+    CodeFamilyPlugin,
+    DecoderCompatibilityMetadata,
+    SyndromeExtractionSpec,
+)
+from .registry import get_plugin, list_plugins, register_plugin
+from .bosonic import BosonicCodePlugin
+from .dual_rail_erasure import DualRailErasureCodePlugin
+from .qldpc import QLDPCCodePlugin
+from .surface import SurfaceCodePlugin
+
+
+register_plugin(SurfaceCodePlugin())
+register_plugin(QLDPCCodePlugin())
+register_plugin(BosonicCodePlugin())
+register_plugin(DualRailErasureCodePlugin())
+
+
+__all__ = [
+    "CircuitGenerationConfig",
+    "CodeFamilyPlugin",
+    "DecoderCompatibilityMetadata",
+    "SyndromeExtractionSpec",
+    "register_plugin",
+    "get_plugin",
+    "list_plugins",
+    "benchmark_code_families",
+    "default_stim_decoder_evaluator",
+    "SurfaceCodePlugin",
+    "QLDPCCodePlugin",
+    "BosonicCodePlugin",
+    "DualRailErasureCodePlugin",
+]

--- a/codes/benchmark.py
+++ b/codes/benchmark.py
@@ -1,0 +1,65 @@
+"""Benchmark harness for evaluating multiple code families uniformly."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from .interfaces import CircuitGenerationConfig, DecoderFn
+from .registry import get_plugin
+
+
+def default_stim_decoder_evaluator(circuit_string: str, shots: int, seed: int | None) -> Mapping[str, Any]:
+    """Evaluate a Stim circuit by estimating logical observable-0 error rate."""
+
+    try:
+        import numpy as np
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("NumPy is required to run benchmark evaluations.") from exc
+
+    try:
+        import stim
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("Stim is required to run benchmark evaluations.") from exc
+
+    circuit = stim.Circuit(circuit_string)
+    if circuit.num_observables == 0:
+        raise ValueError("Circuit must define observable 0 for benchmark evaluation.")
+
+    sampler = circuit.compile_detector_sampler(seed=seed)
+    _, observable_samples = sampler.sample(shots, separate_observables=True)
+    logical_error_rate = float(np.mean(observable_samples[:, 0]))
+
+    return {
+        "logical_error_rate": logical_error_rate,
+        "num_detectors": circuit.num_detectors,
+        "num_observables": circuit.num_observables,
+    }
+
+
+def benchmark_code_families(
+    families: Iterable[str],
+    config: CircuitGenerationConfig,
+    *,
+    shots: int,
+    decoder_evaluator: DecoderFn = default_stim_decoder_evaluator,
+    seed: int | None = None,
+) -> dict[str, Mapping[str, Any]]:
+    """Run the same decoder/evaluation API across multiple code families."""
+
+    if shots <= 0:
+        raise ValueError("shots must be a positive integer.")
+
+    results: dict[str, Mapping[str, Any]] = {}
+    for family in families:
+        plugin = get_plugin(family)
+        metadata = plugin.decoder_metadata()
+        circuit_string = plugin.build_circuit(config)
+        metrics = dict(decoder_evaluator(circuit_string, shots, seed))
+        metrics["decoder_metadata"] = {
+            "compatible_decoders": metadata.compatible_decoders,
+            "required_inputs": metadata.required_inputs,
+            "syndrome_format": metadata.syndrome_spec.format_name,
+        }
+        results[family] = metrics
+
+    return results

--- a/codes/bosonic/__init__.py
+++ b/codes/bosonic/__init__.py
@@ -1,0 +1,5 @@
+"""Bosonic code-family plugin exports."""
+
+from .plugin import BosonicCodePlugin
+
+__all__ = ["BosonicCodePlugin"]

--- a/codes/bosonic/plugin.py
+++ b/codes/bosonic/plugin.py
@@ -1,0 +1,42 @@
+"""Bosonic-code plugin placeholder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..interfaces import (
+    CircuitGenerationConfig,
+    CodeFamilyPlugin,
+    DecoderCompatibilityMetadata,
+    SyndromeExtractionSpec,
+)
+
+
+@dataclass(frozen=True)
+class BosonicCodePlugin(CodeFamilyPlugin):
+    """Minimal plugin scaffold for bosonic code families."""
+
+    family: str = "bosonic"
+
+    def build_circuit(self, config: CircuitGenerationConfig) -> str:
+        _ = config
+        raise NotImplementedError(
+            "Bosonic circuit generation is not implemented. Required inputs depend on the code "
+            "variant and should include a mode Hamiltonian specification in extra_params."
+        )
+
+    def syndrome_spec(self) -> SyndromeExtractionSpec:
+        return SyndromeExtractionSpec(
+            format_name="bosonic_syndrome",
+            detector_axis="measurement_index",
+            observable_axis="logical_subspace_index",
+            supports_separate_observables=False,
+        )
+
+    def decoder_metadata(self) -> DecoderCompatibilityMetadata:
+        return DecoderCompatibilityMetadata(
+            family=self.family,
+            compatible_decoders=("max_likelihood", "particle_filter"),
+            required_inputs=("mode_hamiltonian",),
+            syndrome_spec=self.syndrome_spec(),
+        )

--- a/codes/dual_rail_erasure/__init__.py
+++ b/codes/dual_rail_erasure/__init__.py
@@ -1,0 +1,5 @@
+"""Dual-rail erasure code-family plugin exports."""
+
+from .plugin import DualRailErasureCodePlugin, DualRailErasureParityInput
+
+__all__ = ["DualRailErasureCodePlugin", "DualRailErasureParityInput"]

--- a/codes/dual_rail_erasure/plugin.py
+++ b/codes/dual_rail_erasure/plugin.py
@@ -1,0 +1,52 @@
+"""Dual-rail erasure-code placeholder with explicit input schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..interfaces import (
+    CircuitGenerationConfig,
+    CodeFamilyPlugin,
+    DecoderCompatibilityMetadata,
+    SyndromeExtractionSpec,
+)
+
+
+@dataclass(frozen=True)
+class DualRailErasureParityInput:
+    """Concrete schema for dual-rail erasure parity-check inputs."""
+
+    parity_check: Any
+    erasure_map: Any
+
+
+@dataclass(frozen=True)
+class DualRailErasureCodePlugin(CodeFamilyPlugin):
+    """Placeholder plugin for dual-rail erasure-code circuit generation."""
+
+    family: str = "dual_rail_erasure"
+
+    def build_circuit(self, config: CircuitGenerationConfig) -> str:
+        _ = config
+        raise NotImplementedError(
+            "Dual-rail erasure circuit generation is not implemented. Required parity-check "
+            "inputs: 'parity_check' and 'erasure_map' provided via "
+            "CircuitGenerationConfig.extra_params['parity_inputs'] as DualRailErasureParityInput."
+        )
+
+    def syndrome_spec(self) -> SyndromeExtractionSpec:
+        return SyndromeExtractionSpec(
+            format_name="erasure_aware_syndrome",
+            detector_axis="parity_check_index",
+            observable_axis="logical_rail_index",
+            supports_separate_observables=False,
+        )
+
+    def decoder_metadata(self) -> DecoderCompatibilityMetadata:
+        return DecoderCompatibilityMetadata(
+            family=self.family,
+            compatible_decoders=("erasure_matching", "belief_propagation_erasure"),
+            required_inputs=("parity_check", "erasure_map"),
+            syndrome_spec=self.syndrome_spec(),
+        )

--- a/codes/interfaces.py
+++ b/codes/interfaces.py
@@ -1,0 +1,65 @@
+"""Shared plugin interfaces for quantum error-correction code families."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+
+DecoderFn = Callable[[str, int, int | None], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class CircuitGenerationConfig:
+    """Configuration used by code-family plugins to generate circuits.
+
+    Attributes:
+        distance: Code distance or analogous size parameter.
+        rounds: Number of syndrome-extraction rounds.
+        physical_error_rate: Per-operation physical error rate.
+        extra_params: Family-specific structured parameters.
+    """
+
+    distance: int
+    rounds: int
+    physical_error_rate: float
+    extra_params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyndromeExtractionSpec:
+    """Schema for syndrome extraction outputs expected by decoders."""
+
+    format_name: str
+    detector_axis: str
+    observable_axis: str
+    supports_separate_observables: bool
+
+
+@dataclass(frozen=True)
+class DecoderCompatibilityMetadata:
+    """Metadata describing decoder expectations for a code family."""
+
+    family: str
+    compatible_decoders: tuple[str, ...]
+    required_inputs: tuple[str, ...]
+    syndrome_spec: SyndromeExtractionSpec
+
+
+class CodeFamilyPlugin(ABC):
+    """Base interface that all code-family plugins implement."""
+
+    family: str
+
+    @abstractmethod
+    def build_circuit(self, config: CircuitGenerationConfig) -> str:
+        """Build a Stim-compatible circuit string for the given configuration."""
+
+    @abstractmethod
+    def syndrome_spec(self) -> SyndromeExtractionSpec:
+        """Return the syndrome extraction schema for the family."""
+
+    @abstractmethod
+    def decoder_metadata(self) -> DecoderCompatibilityMetadata:
+        """Return decoder compatibility details for the family."""

--- a/codes/qldpc/__init__.py
+++ b/codes/qldpc/__init__.py
@@ -1,0 +1,5 @@
+"""qLDPC code-family plugin exports."""
+
+from .plugin import QLDPCCodePlugin, QLDPCParityCheckInput
+
+__all__ = ["QLDPCCodePlugin", "QLDPCParityCheckInput"]

--- a/codes/qldpc/plugin.py
+++ b/codes/qldpc/plugin.py
@@ -1,0 +1,52 @@
+"""qLDPC plugin placeholder with explicit parity-check schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..interfaces import (
+    CircuitGenerationConfig,
+    CodeFamilyPlugin,
+    DecoderCompatibilityMetadata,
+    SyndromeExtractionSpec,
+)
+
+
+@dataclass(frozen=True)
+class QLDPCParityCheckInput:
+    """Concrete schema for qLDPC parity-check definitions."""
+
+    hx: Any
+    hz: Any
+
+
+@dataclass(frozen=True)
+class QLDPCCodePlugin(CodeFamilyPlugin):
+    """Placeholder plugin for qLDPC-family circuit generation."""
+
+    family: str = "qldpc"
+
+    def build_circuit(self, config: CircuitGenerationConfig) -> str:
+        _ = config
+        raise NotImplementedError(
+            "qLDPC circuit generation is not implemented. Required parity-check inputs: "
+            "'hx' and 'hz' binary parity-check matrices provided via "
+            "CircuitGenerationConfig.extra_params['parity_checks'] as QLDPCParityCheckInput."
+        )
+
+    def syndrome_spec(self) -> SyndromeExtractionSpec:
+        return SyndromeExtractionSpec(
+            format_name="parity_check_syndrome",
+            detector_axis="check_index",
+            observable_axis="logical_operator_index",
+            supports_separate_observables=False,
+        )
+
+    def decoder_metadata(self) -> DecoderCompatibilityMetadata:
+        return DecoderCompatibilityMetadata(
+            family=self.family,
+            compatible_decoders=("belief_propagation", "osd", "pymatching"),
+            required_inputs=("hx", "hz"),
+            syndrome_spec=self.syndrome_spec(),
+        )

--- a/codes/registry.py
+++ b/codes/registry.py
@@ -1,0 +1,32 @@
+"""In-memory registry for code-family plugins."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .interfaces import CodeFamilyPlugin
+
+
+_PLUGIN_REGISTRY: Dict[str, CodeFamilyPlugin] = {}
+
+
+def register_plugin(plugin: CodeFamilyPlugin) -> None:
+    """Register a plugin under its family name."""
+
+    _PLUGIN_REGISTRY[plugin.family] = plugin
+
+
+def get_plugin(family: str) -> CodeFamilyPlugin:
+    """Return a plugin by family name."""
+
+    try:
+        return _PLUGIN_REGISTRY[family]
+    except KeyError as exc:
+        available = ", ".join(sorted(_PLUGIN_REGISTRY)) or "<none>"
+        raise KeyError(f"Unknown code family '{family}'. Available families: {available}.") from exc
+
+
+def list_plugins() -> tuple[str, ...]:
+    """Return all registered plugin family names."""
+
+    return tuple(sorted(_PLUGIN_REGISTRY))

--- a/codes/surface/__init__.py
+++ b/codes/surface/__init__.py
@@ -1,0 +1,17 @@
+"""Surface code-family plugin and compatibility wrappers."""
+
+from .plugin import SurfaceCodePlugin
+from .wrappers import (
+    hexagonal_surface_code,
+    iswap_surface_code,
+    surface_code_circuit_string,
+    walking_surface_code,
+)
+
+__all__ = [
+    "SurfaceCodePlugin",
+    "surface_code_circuit_string",
+    "hexagonal_surface_code",
+    "walking_surface_code",
+    "iswap_surface_code",
+]

--- a/codes/surface/plugin.py
+++ b/codes/surface/plugin.py
@@ -1,0 +1,54 @@
+"""Surface-code plugin wrappers around existing builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from surface_code_in_stem.dynamic import hexagonal_surface_code, iswap_surface_code, walking_surface_code
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+from ..interfaces import (
+    CircuitGenerationConfig,
+    CodeFamilyPlugin,
+    DecoderCompatibilityMetadata,
+    SyndromeExtractionSpec,
+)
+
+
+@dataclass(frozen=True)
+class SurfaceCodePlugin(CodeFamilyPlugin):
+    """Plugin providing access to static and dynamic surface-code builders."""
+
+    family: str = "surface"
+
+    def build_circuit(self, config: CircuitGenerationConfig) -> str:
+        variant = str(config.extra_params.get("variant", "static")).lower()
+        builders = {
+            "static": surface_code_circuit_string,
+            "hexagonal": hexagonal_surface_code,
+            "walking": walking_surface_code,
+            "iswap": iswap_surface_code,
+        }
+        try:
+            builder = builders[variant]
+        except KeyError as exc:
+            valid = ", ".join(sorted(builders))
+            raise ValueError(f"Unknown surface variant '{variant}'. Expected one of: {valid}.") from exc
+
+        return builder(config.distance, config.rounds, config.physical_error_rate)
+
+    def syndrome_spec(self) -> SyndromeExtractionSpec:
+        return SyndromeExtractionSpec(
+            format_name="stim_detector_sampler",
+            detector_axis="detector_index",
+            observable_axis="observable_index",
+            supports_separate_observables=True,
+        )
+
+    def decoder_metadata(self) -> DecoderCompatibilityMetadata:
+        return DecoderCompatibilityMetadata(
+            family=self.family,
+            compatible_decoders=("pymatching", "union_find", "custom_stim_decoder"),
+            required_inputs=("stim_circuit",),
+            syndrome_spec=self.syndrome_spec(),
+        )

--- a/codes/surface/wrappers.py
+++ b/codes/surface/wrappers.py
@@ -1,0 +1,13 @@
+"""Compatibility wrappers for existing surface builders."""
+
+from __future__ import annotations
+
+from surface_code_in_stem.dynamic import hexagonal_surface_code, iswap_surface_code, walking_surface_code
+from surface_code_in_stem.surface_code import surface_code_circuit_string
+
+__all__ = [
+    "surface_code_circuit_string",
+    "hexagonal_surface_code",
+    "walking_surface_code",
+    "iswap_surface_code",
+]

--- a/surface_code_in_stem/__init__.py
+++ b/surface_code_in_stem/__init__.py
@@ -1,5 +1,7 @@
 """Surface code builders and helpers."""
 
+from __future__ import annotations
+
 from .surface_code import surface_code_circuit_string
 from .dynamic_surface_codes import (
     DynamicLayout,
@@ -8,7 +10,23 @@ from .dynamic_surface_codes import (
     iswap_surface_code,
     walking_surface_code,
 )
-from .rl_nested_learning import compare_nested_policies, tabulate_comparison
+
+
+def compare_nested_policies(*args, **kwargs):
+    """Lazy wrapper for RL comparison utility to preserve import compatibility."""
+
+    from .rl_nested_learning import compare_nested_policies as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def tabulate_comparison(*args, **kwargs):
+    """Lazy wrapper for RL comparison tabulation utility."""
+
+    from .rl_nested_learning import tabulate_comparison as _impl
+
+    return _impl(*args, **kwargs)
+
 
 __all__ = [
     "surface_code_circuit_string",
@@ -20,4 +38,3 @@ __all__ = [
     "compare_nested_policies",
     "tabulate_comparison",
 ]
-

--- a/tests/test_code_family_plugins.py
+++ b/tests/test_code_family_plugins.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from codes import CircuitGenerationConfig, benchmark_code_families, list_plugins
+from codes.dual_rail_erasure import DualRailErasureCodePlugin
+from codes.qldpc import QLDPCCodePlugin
+
+
+def test_plugin_registry_includes_requested_code_families():
+    families = set(list_plugins())
+    assert {"surface", "qldpc", "bosonic", "dual_rail_erasure"}.issubset(families)
+
+
+def test_qldpc_placeholder_error_message_is_explicit():
+    plugin = QLDPCCodePlugin()
+    with pytest.raises(NotImplementedError, match="Required parity-check inputs: 'hx' and 'hz'"):
+        plugin.build_circuit(CircuitGenerationConfig(distance=3, rounds=2, physical_error_rate=0.001))
+
+
+def test_dual_rail_placeholder_error_message_is_explicit():
+    plugin = DualRailErasureCodePlugin()
+    with pytest.raises(NotImplementedError, match="'parity_check' and 'erasure_map'"):
+        plugin.build_circuit(CircuitGenerationConfig(distance=3, rounds=2, physical_error_rate=0.001))
+
+
+def test_benchmark_harness_runs_surface_family_with_shared_api():
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("stim")
+
+    config = CircuitGenerationConfig(
+        distance=3,
+        rounds=2,
+        physical_error_rate=0.001,
+        extra_params={"variant": "static"},
+    )
+    results = benchmark_code_families(["surface"], config, shots=8, seed=5)
+
+    assert set(results) == {"surface"}
+    assert 0.0 <= results["surface"]["logical_error_rate"] <= 1.0
+    assert np.isfinite(results["surface"]["logical_error_rate"])
+    assert results["surface"]["decoder_metadata"]["syndrome_format"] == "stim_detector_sampler"


### PR DESCRIPTION
### Motivation
- Provide a clean, extensible plugin surface for multiple code families so decoders and benchmarks can operate over a single API.
- Expose existing surface-code builders through a plugin adapter while preparing pluggable placeholders for qLDPC, bosonic, and erasure-based families.
- Standardize the schema for circuit generation, syndrome extraction, and decoder compatibility metadata to make cross-family tooling simpler.

### Description
- Added a new top-level `codes/` package with a plugin registry and automatic registration for families `surface`, `qldpc`, `bosonic`, and `dual_rail_erasure`.
- Introduced shared interfaces in `codes/interfaces.py` including `CircuitGenerationConfig`, `SyndromeExtractionSpec`, `DecoderCompatibilityMetadata`, and the abstract `CodeFamilyPlugin` base class.
- Implemented `codes/surface/` wrappers and `SurfaceCodePlugin` that route to existing builders (`static`, `hexagonal`, `walking`, `iswap`) and preserved import compatibility in `surface_code_in_stem/__init__.py` via lazy wrappers.
- Added minimal placeholder plugins for `qldpc`, `bosonic`, and `dual_rail_erasure` that raise explicit `NotImplementedError` messages describing required parity-check or Hamiltonian inputs (no ambiguous TODO strings).
- Added a family-agnostic benchmark harness in `codes/benchmark.py` (`benchmark_code_families`) and a default Stim-based evaluator `default_stim_decoder_evaluator` that returns `logical_error_rate`, `num_detectors`, and `num_observables` together with decoder metadata.
- Added tests `tests/test_code_family_plugins.py` that validate plugin registration, explicit placeholder error messages, and the benchmark harness running the `surface` family via the shared API.

### Testing
- Ran `pytest -q tests/test_code_family_plugins.py` with environment-protected imports for optional deps: result `3 passed, 1 skipped`.
- Ran full test suite `pytest -q`: result `3 passed, 2 skipped` indicating optional Stim/NumPy-dependent paths are correctly guarded and conditionally skipped when missing.
- Tests verify `list_plugins()` contains `surface`, `qldpc`, `bosonic`, and `dual_rail_erasure`, that placeholder plugins raise `NotImplementedError` with clear required-input messages, and that the benchmark harness returns finite `logical_error_rate` and correct `syndrome_format` metadata for the `surface` family.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0661922148328adc335d13ec5adc6)

## Summary by Sourcery

Introduce a shared code-family plugin system with a common benchmark API and adapt existing surface-code builders into this extensible framework.

New Features:
- Add a top-level codes package providing a plugin registry, shared interfaces, and a family-agnostic benchmark harness.
- Expose a surface-code plugin that routes through compatibility wrappers to existing static and dynamic surface-code circuit builders.
- Provide placeholder plugins for qLDPC, bosonic, and dual-rail erasure code families with explicit input schemas and metadata.

Enhancements:
- Update the surface_code_in_stem package with lazy wrappers to preserve existing RL utility imports without importing heavy dependencies eagerly.
- Document the new codes package layout and plugin families in the project Readme.

Tests:
- Add tests covering plugin registration, explicit placeholder error messages, and running the benchmark harness against the surface family via the shared API.