### PR TITLE
Add benchmarks package with CLI, specs, models, plots, and tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,3 +96,15 @@ flowchart TD
     F4 --> D0
     F4 --> E1
 ```
+
+
+## Benchmarking
+
+Structured benchmark specs live in `benchmarks/specs/` and can be executed through a single CLI entrypoint:
+
+```bash
+python -m benchmarks benchmarks/specs/threshold_sweep.yaml benchmarks/specs/distance_scaling.yaml
+```
+
+Each run writes CSV metrics and PNG plots to `benchmarks/results/` by default.
+See `benchmarks/reproduce.md` for a mapping between templates and literature claims/caveats.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmarking utilities for quantum error-correction experiments."""

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -1,0 +1,5 @@
+from benchmarks.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cli.py
+++ b/benchmarks/cli.py
@@ -1,0 +1,43 @@
+"""CLI entrypoint for running quantum error-correction benchmark specs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from benchmarks.config import load_spec
+from benchmarks.runner import run_spec
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create argument parser for benchmark execution."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "specs",
+        nargs="+",
+        help="One or more YAML/JSON spec files to execute.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="benchmarks/results",
+        help="Directory where CSV and plots are written.",
+    )
+    return parser
+
+
+def main() -> None:
+    """CLI main function."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for spec_path in args.specs:
+        spec = load_spec(spec_path)
+        frame = run_spec(spec, output_dir=output_dir)
+        print(f"[{spec.name}] rows={len(frame)} -> {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/config.py
+++ b/benchmarks/config.py
@@ -1,0 +1,70 @@
+"""Configuration loading for benchmark experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(slots=True)
+class BenchmarkSpec:
+    """Normalized benchmark specification parsed from YAML/JSON."""
+
+    name: str
+    benchmark_type: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    output_prefix: str | None = None
+
+
+SUPPORTED_BENCHMARKS = {
+    "threshold_sweep",
+    "distance_scaling",
+    "repetition_suppression",
+    "overhead_comparison",
+}
+
+
+def _read_raw_spec(path: Path) -> dict[str, Any]:
+    """Read a benchmark specification from YAML or JSON."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(path.read_text())
+    if suffix in {".yaml", ".yml"}:
+        data = yaml.safe_load(path.read_text())
+        if not isinstance(data, dict):
+            raise ValueError(f"YAML spec must map to a dictionary: {path}")
+        return data
+    raise ValueError(f"Unsupported spec format '{suffix}' for {path}")
+
+
+def load_spec(path: str | Path) -> BenchmarkSpec:
+    """Load and validate a benchmark spec file."""
+    spec_path = Path(path)
+    raw = _read_raw_spec(spec_path)
+
+    benchmark_type = raw.get("benchmark_type")
+    if benchmark_type not in SUPPORTED_BENCHMARKS:
+        raise ValueError(
+            f"Unknown benchmark_type '{benchmark_type}'. "
+            f"Supported: {sorted(SUPPORTED_BENCHMARKS)}"
+        )
+
+    name = raw.get("name") or spec_path.stem
+    parameters = raw.get("parameters", {})
+    if not isinstance(parameters, dict):
+        raise ValueError("'parameters' must be a dictionary")
+
+    output_prefix = raw.get("output_prefix")
+    if output_prefix is not None and not isinstance(output_prefix, str):
+        raise ValueError("'output_prefix' must be a string when provided")
+
+    return BenchmarkSpec(
+        name=name,
+        benchmark_type=benchmark_type,
+        parameters=parameters,
+        output_prefix=output_prefix,
+    )

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -1,0 +1,83 @@
+"""Analytical benchmark models for quantum error-correction experiments."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+
+def repetition_logical_error_rate(distance: int, physical_error_rate: float) -> float:
+    """Majority-vote logical error probability for odd-distance repetition code."""
+    if distance <= 0 or distance % 2 == 0:
+        raise ValueError("distance must be a positive odd integer")
+    if not 0.0 <= physical_error_rate <= 1.0:
+        raise ValueError("physical_error_rate must be in [0, 1]")
+
+    start = distance // 2 + 1
+    return sum(
+        math.comb(distance, flips)
+        * (physical_error_rate**flips)
+        * ((1 - physical_error_rate) ** (distance - flips))
+        for flips in range(start, distance + 1)
+    )
+
+
+def surface_code_logical_error_rate(
+    distance: int,
+    physical_error_rate: float,
+    threshold: float,
+    prefactor: float = 0.1,
+) -> float:
+    """Power-law surrogate for surface-code logical error rate below threshold."""
+    if distance <= 0:
+        raise ValueError("distance must be positive")
+    exponent = (distance + 1) / 2
+    ratio = max(physical_error_rate, 1e-15) / max(threshold, 1e-15)
+    return min(1.0, prefactor * (ratio**exponent))
+
+
+def qldpc_logical_error_rate(
+    distance: int,
+    physical_error_rate: float,
+    threshold: float,
+    alpha: float,
+    prefactor: float = 0.08,
+) -> float:
+    """Simple qLDPC-inspired scaling model with linear-in-distance exponent."""
+    if distance <= 0:
+        raise ValueError("distance must be positive")
+    ratio = max(physical_error_rate, 1e-15) / max(threshold, 1e-15)
+    exponent = alpha * distance
+    return min(1.0, prefactor * (ratio**exponent))
+
+
+def suppression_factors(logical_rates: Iterable[float]) -> list[float | None]:
+    """Compute suppression factors between consecutive logical error rates."""
+    rates = list(logical_rates)
+    if not rates:
+        return []
+
+    factors: list[float | None] = [None]
+    for prev, curr in zip(rates[:-1], rates[1:]):
+        if curr <= 0:
+            factors.append(None)
+        else:
+            factors.append(prev / curr)
+    return factors
+
+
+def estimate_surface_overhead(distance: int) -> tuple[int, int, float]:
+    """Return qubit overhead, cycle count, and decoder latency estimate (microseconds)."""
+    qubits = 2 * distance * distance
+    cycles = distance
+    decode_latency_us = 8.0 * distance
+    return qubits, cycles, decode_latency_us
+
+
+def estimate_qldpc_overhead(distance: int, rate: float = 0.1) -> tuple[int, int, float]:
+    """Crude qLDPC overhead assuming constant check weight and batched decoding."""
+    logical_qubits = max(1, distance // 2)
+    physical_qubits = int(math.ceil(logical_qubits / rate))
+    cycles = int(math.ceil(math.log2(distance + 1)))
+    decode_latency_us = 25.0 * math.log2(distance + 1)
+    return physical_qubits, cycles, decode_latency_us

--- a/benchmarks/reproduce.md
+++ b/benchmarks/reproduce.md
@@ -1,0 +1,33 @@
+# Benchmark reproduction map
+
+This document maps each benchmark template in `benchmarks/specs/` to commonly cited literature-level claims and highlights caveats when using these templates as proxies instead of full decoder-in-the-loop simulations.
+
+## 1) Threshold sweep (`threshold_sweep.yaml`)
+
+- **Target claim:** logical error curves for increasing code distance cross near a threshold region (surface code style behavior).
+- **Typical references:** Fowler et al., *Surface codes: Towards practical large-scale quantum computation* (PRA 2012); Dennis et al., *Topological quantum memory* (JMP 2002).
+- **Caveats:** this benchmark uses a compact power-law surrogate rather than explicit syndrome sampling and MWPM decoding, so extracted threshold values are illustrative and not publication-grade.
+
+## 2) Distance scaling (`distance_scaling.yaml`)
+
+- **Target claim:** below threshold, logical error rate drops roughly exponentially with code distance.
+- **Typical references:** textbook surface-code scaling arguments and supplemental scaling analyses in architecture papers.
+- **Caveats:** assumes a fixed effective threshold and prefactor; hardware-specific correlated noise, leakage, and decoder mismatch are not represented.
+
+## 3) Repetition code exponential suppression (`repetition_suppression.json`)
+
+- **Target claim:** odd-distance repetition code under iid bit-flip noise exhibits exponential suppression from majority vote decoding.
+- **Typical references:** standard repetition-code derivations; didactic Stim tutorials.
+- **Caveats:** model is exact only for iid single-parameter bit-flip channels and perfect measurements, without time-correlated noise or measurement faults.
+
+## 4) Overhead comparison (`overhead_comparison.yaml`)
+
+- **Target claim:** compare order-of-magnitude resource and latency trade-offs between surface-code and qLDPC-style assumptions.
+- **Typical references:** recent qLDPC resource-estimation discussions (e.g., Panteleev-Kalachev line of work and follow-on architecture analyses).
+- **Caveats:** qLDPC terms here are intentionally templated assumptions (rate, scaling exponent, latency law) and should be replaced with family-specific decoder/architecture data before drawing hardware conclusions.
+
+## Practical reproducibility notes
+
+1. Pin package versions and random seeds for deterministic CSV outputs.
+2. Archive generated `benchmarks/results/*.csv` with commits.
+3. Treat plots as quick diagnostics; for papers, regenerate from raw artifacts and include confidence intervals from Monte Carlo trials.

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -1,0 +1,192 @@
+"""Benchmark execution and artifact generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from benchmarks.config import BenchmarkSpec
+from benchmarks.models import (
+    estimate_qldpc_overhead,
+    estimate_surface_overhead,
+    qldpc_logical_error_rate,
+    repetition_logical_error_rate,
+    suppression_factors,
+    surface_code_logical_error_rate,
+)
+
+
+def _distance_list(parameters: dict[str, Any]) -> list[int]:
+    distances = parameters.get("distances", [3, 5, 7])
+    return [int(d) for d in distances]
+
+
+def run_spec(spec: BenchmarkSpec, output_dir: str | Path) -> pd.DataFrame:
+    """Execute a benchmark spec and materialize dataframe metrics."""
+    if spec.benchmark_type == "threshold_sweep":
+        df = _run_threshold_sweep(spec.parameters)
+    elif spec.benchmark_type == "distance_scaling":
+        df = _run_distance_scaling(spec.parameters)
+    elif spec.benchmark_type == "repetition_suppression":
+        df = _run_repetition_suppression(spec.parameters)
+    elif spec.benchmark_type == "overhead_comparison":
+        df = _run_overhead_comparison(spec.parameters)
+    else:
+        raise ValueError(f"Unsupported benchmark type: {spec.benchmark_type}")
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    prefix = spec.output_prefix or spec.name
+    csv_path = out / f"{prefix}.csv"
+    df.to_csv(csv_path, index=False)
+    _save_plot(spec, df, out / f"{prefix}.png")
+    return df
+
+
+def _run_threshold_sweep(parameters: dict[str, Any]) -> pd.DataFrame:
+    distances = _distance_list(parameters)
+    p_values = [float(p) for p in parameters.get("physical_error_rates", [1e-4, 3e-4, 1e-3, 3e-3])]
+    threshold = float(parameters.get("threshold", 1e-2))
+
+    rows: list[dict[str, Any]] = []
+    for d in distances:
+        for p in p_values:
+            logical = surface_code_logical_error_rate(d, p, threshold=threshold)
+            qubits, cycles, latency = estimate_surface_overhead(d)
+            rows.append(
+                {
+                    "benchmark": "threshold_sweep",
+                    "distance": d,
+                    "physical_error_rate": p,
+                    "logical_error_rate": logical,
+                    "qubit_overhead": qubits,
+                    "cycle_count_estimate": cycles,
+                    "decode_latency_us_estimate": latency,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _run_distance_scaling(parameters: dict[str, Any]) -> pd.DataFrame:
+    distances = _distance_list(parameters)
+    p = float(parameters.get("physical_error_rate", 1e-3))
+    threshold = float(parameters.get("threshold", 1e-2))
+
+    logical_rates = [surface_code_logical_error_rate(d, p, threshold=threshold) for d in distances]
+    suppressions = suppression_factors(logical_rates)
+
+    rows = []
+    for d, logical, suppression in zip(distances, logical_rates, suppressions):
+        qubits, cycles, latency = estimate_surface_overhead(d)
+        rows.append(
+            {
+                "benchmark": "distance_scaling",
+                "distance": d,
+                "physical_error_rate": p,
+                "logical_error_rate": logical,
+                "suppression_factor": suppression,
+                "qubit_overhead": qubits,
+                "cycle_count_estimate": cycles,
+                "decode_latency_us_estimate": latency,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _run_repetition_suppression(parameters: dict[str, Any]) -> pd.DataFrame:
+    distances = _distance_list(parameters)
+    p_values = [float(p) for p in parameters.get("physical_error_rates", [1e-3, 2e-3])]
+
+    rows = []
+    for p in p_values:
+        logical_rates = [repetition_logical_error_rate(d, p) for d in distances]
+        suppressions = suppression_factors(logical_rates)
+        for d, logical, suppression in zip(distances, logical_rates, suppressions):
+            rows.append(
+                {
+                    "benchmark": "repetition_suppression",
+                    "distance": d,
+                    "physical_error_rate": p,
+                    "logical_error_rate": logical,
+                    "suppression_factor": suppression,
+                    "qubit_overhead": d,
+                    "cycle_count_estimate": d,
+                    "decode_latency_us_estimate": float(d),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _run_overhead_comparison(parameters: dict[str, Any]) -> pd.DataFrame:
+    distances = _distance_list(parameters)
+    p = float(parameters.get("physical_error_rate", 1e-3))
+    rows = []
+
+    for d in distances:
+        s_ler = surface_code_logical_error_rate(d, p, threshold=float(parameters.get("surface_threshold", 1e-2)))
+        s_q, s_c, s_lat = estimate_surface_overhead(d)
+        rows.append(
+            {
+                "benchmark": "overhead_comparison",
+                "assumption": "surface",
+                "distance": d,
+                "physical_error_rate": p,
+                "logical_error_rate": s_ler,
+                "qubit_overhead": s_q,
+                "cycle_count_estimate": s_c,
+                "decode_latency_us_estimate": s_lat,
+            }
+        )
+
+        q_ler = qldpc_logical_error_rate(
+            d,
+            p,
+            threshold=float(parameters.get("qldpc_threshold", 5e-3)),
+            alpha=float(parameters.get("qldpc_alpha", 0.4)),
+        )
+        q_q, q_c, q_lat = estimate_qldpc_overhead(d, rate=float(parameters.get("qldpc_rate", 0.1)))
+        rows.append(
+            {
+                "benchmark": "overhead_comparison",
+                "assumption": "qldpc",
+                "distance": d,
+                "physical_error_rate": p,
+                "logical_error_rate": q_ler,
+                "qubit_overhead": q_q,
+                "cycle_count_estimate": q_c,
+                "decode_latency_us_estimate": q_lat,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _save_plot(spec: BenchmarkSpec, df: pd.DataFrame, plot_path: Path) -> None:
+    """Save a basic plot for quick report generation."""
+    plt.figure(figsize=(7, 4.5))
+    if spec.benchmark_type == "threshold_sweep":
+        for distance, group in df.groupby("distance"):
+            plt.loglog(group["physical_error_rate"], group["logical_error_rate"], marker="o", label=f"d={distance}")
+        plt.xlabel("Physical error rate")
+        plt.ylabel("Logical error rate")
+        plt.legend()
+    elif spec.benchmark_type in {"distance_scaling", "repetition_suppression"}:
+        if "physical_error_rate" in df.columns and df["physical_error_rate"].nunique() > 1:
+            for physical_error_rate, group in df.groupby("physical_error_rate"):
+                plt.semilogy(group["distance"], group["logical_error_rate"], marker="o", label=f"p={physical_error_rate}")
+            plt.legend()
+        else:
+            plt.semilogy(df["distance"], df["logical_error_rate"], marker="o")
+        plt.xlabel("Code distance")
+        plt.ylabel("Logical error rate")
+    else:
+        pivot = df.pivot(index="distance", columns="assumption", values="qubit_overhead")
+        pivot.plot(kind="bar", ax=plt.gca())
+        plt.ylabel("Qubit overhead")
+
+    plt.title(spec.name)
+    plt.tight_layout()
+    plt.savefig(plot_path, dpi=200)
+    plt.close()

--- a/benchmarks/specs/distance_scaling.yaml
+++ b/benchmarks/specs/distance_scaling.yaml
@@ -1,0 +1,7 @@
+name: distance_scaling_surface
+benchmark_type: distance_scaling
+output_prefix: distance_scaling_surface
+parameters:
+  distances: [3, 5, 7, 9, 11]
+  physical_error_rate: 0.001
+  threshold: 0.01

--- a/benchmarks/specs/overhead_comparison.yaml
+++ b/benchmarks/specs/overhead_comparison.yaml
@@ -1,0 +1,10 @@
+name: overhead_surface_vs_qldpc
+benchmark_type: overhead_comparison
+output_prefix: overhead_surface_vs_qldpc
+parameters:
+  distances: [3, 5, 7, 9, 11]
+  physical_error_rate: 0.001
+  surface_threshold: 0.01
+  qldpc_threshold: 0.005
+  qldpc_alpha: 0.4
+  qldpc_rate: 0.1

--- a/benchmarks/specs/repetition_suppression.json
+++ b/benchmarks/specs/repetition_suppression.json
@@ -1,0 +1,9 @@
+{
+  "name": "repetition_exponential_suppression",
+  "benchmark_type": "repetition_suppression",
+  "output_prefix": "repetition_exponential_suppression",
+  "parameters": {
+    "distances": [3, 5, 7, 9],
+    "physical_error_rates": [0.001, 0.002, 0.005]
+  }
+}

--- a/benchmarks/specs/threshold_sweep.yaml
+++ b/benchmarks/specs/threshold_sweep.yaml
@@ -1,0 +1,7 @@
+name: threshold_sweep_surface
+benchmark_type: threshold_sweep
+output_prefix: threshold_sweep_surface
+parameters:
+  distances: [3, 5, 7, 9]
+  physical_error_rates: [0.0003, 0.0006, 0.001, 0.002, 0.003]
+  threshold: 0.01

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import math
+
+import pandas as pd
+
+from benchmarks.config import load_spec
+from benchmarks.models import suppression_factors
+from benchmarks.runner import run_spec
+
+
+def test_load_spec_yaml_and_json():
+    threshold = load_spec("benchmarks/specs/threshold_sweep.yaml")
+    repetition = load_spec("benchmarks/specs/repetition_suppression.json")
+
+    assert threshold.benchmark_type == "threshold_sweep"
+    assert repetition.benchmark_type == "repetition_suppression"
+    assert "distances" in threshold.parameters
+    assert "physical_error_rates" in repetition.parameters
+
+
+def test_suppression_factor_aggregation():
+    factors = suppression_factors([1e-1, 1e-2, 2e-3])
+    assert factors[0] is None
+    assert math.isclose(factors[1], 10.0)
+    assert math.isclose(factors[2], 5.0)
+
+
+def test_run_spec_outputs_expected_metrics(tmp_path):
+    spec = load_spec("benchmarks/specs/distance_scaling.yaml")
+    df = run_spec(spec, output_dir=tmp_path)
+
+    required_columns = {
+        "logical_error_rate",
+        "suppression_factor",
+        "qubit_overhead",
+        "cycle_count_estimate",
+        "decode_latency_us_estimate",
+    }
+    assert required_columns.issubset(df.columns)
+    assert isinstance(df, pd.DataFrame)
+    assert (tmp_path / f"{spec.output_prefix}.csv").exists()
+    assert (tmp_path / f"{spec.output_prefix}.png").exists()


### PR DESCRIPTION
### Motivation

- Provide a reproducible, lightweight benchmarking scaffold for quick comparisons of code families (surface code, repetition code, qLDPC assumptions) without full Monte Carlo decoders. 
- Enable structured experiment definitions via YAML/JSON so experiments are shareable and scriptable. 
- Produce machine-readable artifacts (CSV) and quick diagnostics (PNG) to support result archiving and downstream plotting/analysis.

### Description

- Add a new `benchmarks/` package with a CLI entrypoint (`python -m benchmarks`) that loads specs and dispatches benchmark flows (`benchmarks/cli.py`, `benchmarks/__main__.py`, `benchmarks/__init__.py`).
- Implement spec loading and validation for supported benchmark types in `benchmarks/config.py` and provide example YAML/JSON templates in `benchmarks/specs/` for `threshold_sweep`, `distance_scaling`, `repetition_suppression`, and `overhead_comparison`.
- Provide compact analytical models and metric helpers in `benchmarks/models.py` (logical error surrogates, suppression-factor aggregation, qubit/cycle/latency estimators) and a runner that materializes metrics, writes CSVs and PNGs, and basic plotting in `benchmarks/runner.py`.
- Add `benchmarks/reproduce.md` mapping each spec to literature-style claims and caveats, update `Readme.md` with CLI usage, and add regression tests in `tests/test_benchmarks.py` covering spec parsing, aggregation, and artifact generation.

### Testing

- Installed runtime deps with `pip install pyyaml matplotlib pandas` and ran the test-suite using `pytest -q`, which succeeded (`3 passed, 1 skipped`).
- Exercised the CLI to run all templates using `python -m benchmarks benchmarks/specs/threshold_sweep.yaml benchmarks/specs/distance_scaling.yaml benchmarks/specs/repetition_suppression.json benchmarks/specs/overhead_comparison.yaml`, which produced CSV and PNG artifacts in `benchmarks/results/`.
- Unit tests validate `load_spec`, `suppression_factors`, and that `run_spec` returns DataFrames with required metric columns and writes the expected files (CSV + PNG).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0661a79bc8328be9d471018767971)

## Summary by Sourcery

Introduce a new benchmarks package providing a CLI-driven framework for running quantum error-correction benchmarking specs and generating CSV and plot artifacts.

New Features:
- Add a benchmarks package with a CLI entrypoint to execute YAML/JSON benchmark specifications and write results to disk.
- Provide analytical models for surface codes, repetition codes, and qLDPC-style assumptions to compute logical error rates and resource estimates.
- Add configurable benchmark runners for threshold sweeps, distance scaling, repetition suppression, and overhead comparison, producing tabular metrics and plots.
- Include example benchmark spec templates for common experiment types to enable reproducible runs and comparisons.
- Document benchmarking usage and reproduction mapping between specs and literature-style claims.

Tests:
- Add regression tests covering spec loading from YAML/JSON, suppression factor aggregation, and that benchmark runs emit expected metrics and artifact files.